### PR TITLE
mip: track new Go Cryptographic Module submission (4/25/2026)

### DIFF
--- a/mip/README.md
+++ b/mip/README.md
@@ -1,6 +1,6 @@
-# Review Pending Parser
+# Pending Review Parser
 
-This Go program parses the NIST Cryptographic Module Validation Program (CMVP) "Modules In Process" HTML page to extract all entries that are in "Review Pending" status and counts how many entered the queue before a specified cutoff date (5/8/2025).
+This Go program parses the NIST Cryptographic Module Validation Program (CMVP) "Modules In Process" HTML page to extract all entries that are in "Pending Review" status and counts how many entered the queue before a specified cutoff date (4/25/2026).
 
 ## Usage
 
@@ -25,16 +25,16 @@ By default, the program downloads the latest data from the NIST website. Use the
 - **Live data**: Downloads the latest modules list from NIST website by default
 - **Local file support**: Can work with saved HTML files using `-local` flag
 - Parses HTML table structure to extract module information
-- Filters for entries with "Review Pending" status
-- Extracts dates from status field (format: "Review Pending (MM/DD/YYYY)")
-- Counts entries that entered the queue before 5/8/2025
+- Filters for entries with "Pending Review" status
+- Extracts dates from status field (format: "Pending Review (MM/DD/YYYY)")
+- Counts entries that entered the queue before 4/25/2026
 - Provides both detailed output and summary-only mode
 
 ## Example Output
 
 ```
-Total Review Pending entries: 180
-Entries before 5/8/2025: 151
+Total Pending Review entries: 105
+Entries before 4/25/2026: 77
 ```
 
 ## Dependencies

--- a/mip/main.go
+++ b/mip/main.go
@@ -57,21 +57,21 @@ func main() {
 	var entries []ModuleEntry
 	parseTable(doc, &entries)
 
-	// Filter for Review Pending entries
-	reviewPendingEntries := filterReviewPending(entries)
+	// Filter for Pending Review entries
+	pendingReviewEntries := filterPendingReview(entries)
 
-	// Count entries before 5/8/2025
-	cutoffDate := time.Date(2025, 5, 8, 0, 0, 0, 0, time.UTC)
+	// Count entries before 4/25/2026
+	cutoffDate := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
 	countBefore := 0
 
-	for _, entry := range reviewPendingEntries {
+	for _, entry := range pendingReviewEntries {
 		if entry.Date.Before(cutoffDate) {
 			countBefore++
 		}
 	}
 
-	fmt.Printf("Total Review Pending entries: %d\n", len(reviewPendingEntries))
-	fmt.Printf("Entries before 5/8/2025: %d\n", countBefore)
+	fmt.Printf("Total Pending Review entries: %d\n", len(pendingReviewEntries))
+	fmt.Printf("Entries before 4/25/2026: %d\n", countBefore)
 }
 
 func parseTable(n *html.Node, entries *[]ModuleEntry) {
@@ -132,8 +132,8 @@ func parseTableRow(tr *html.Node) *ModuleEntry {
 		Status:     cells[3],
 	}
 
-	// Parse date from status field if it contains "Review Pending (date)"
-	if strings.Contains(entry.Status, "Review Pending") {
+	// Parse date from status field if it contains "Pending Review (date)"
+	if strings.Contains(entry.Status, "Pending Review") {
 		date := parseDate(entry.Status)
 		if !date.IsZero() {
 			entry.Date = date
@@ -156,8 +156,8 @@ func extractText(n *html.Node) string {
 }
 
 func parseDate(status string) time.Time {
-	// Extract date from "Review Pending (MM/DD/YYYY)" format
-	re := regexp.MustCompile(`Review Pending\s+\((\d{1,2})/(\d{1,2})/(\d{4})\)`)
+	// Extract date from "Pending Review (MM/DD/YYYY)" format
+	re := regexp.MustCompile(`Pending Review\s+\((\d{1,2})/(\d{1,2})/(\d{4})\)`)
 	matches := re.FindStringSubmatch(status)
 	if len(matches) != 4 {
 		return time.Time{}
@@ -174,10 +174,10 @@ func parseDate(status string) time.Time {
 	return date
 }
 
-func filterReviewPending(entries []ModuleEntry) []ModuleEntry {
+func filterPendingReview(entries []ModuleEntry) []ModuleEntry {
 	var filtered []ModuleEntry
 	for _, entry := range entries {
-		if strings.Contains(entry.Status, "Review Pending") {
+		if strings.Contains(entry.Status, "Pending Review") {
 			filtered = append(filtered, entry)
 		}
 	}

--- a/mip/main_test.go
+++ b/mip/main_test.go
@@ -26,39 +26,39 @@ func TestParseModulesInProcessList(t *testing.T) {
 	var entries []ModuleEntry
 	parseTable(doc, &entries)
 
-	// Filter for Review Pending entries
-	reviewPendingEntries := filterReviewPending(entries)
+	// Filter for Pending Review entries
+	pendingReviewEntries := filterPendingReview(entries)
 
-	// Test 1: Check total number of Review Pending entries
-	expectedTotal := 180
-	if len(reviewPendingEntries) != expectedTotal {
-		t.Errorf("Expected %d Review Pending entries, got %d", expectedTotal, len(reviewPendingEntries))
+	// Test 1: Check total number of Pending Review entries
+	expectedTotal := 105
+	if len(pendingReviewEntries) != expectedTotal {
+		t.Errorf("Expected %d Pending Review entries, got %d", expectedTotal, len(pendingReviewEntries))
 	}
 
-	// Test 2: Count entries before 5/8/2025
-	cutoffDate := time.Date(2025, 5, 8, 0, 0, 0, 0, time.UTC)
+	// Test 2: Count entries before 4/25/2026
+	cutoffDate := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
 	countBefore := 0
-	for _, entry := range reviewPendingEntries {
+	for _, entry := range pendingReviewEntries {
 		if entry.Date.Before(cutoffDate) {
 			countBefore++
 		}
 	}
 
-	expectedBeforeCutoff := 151
+	expectedBeforeCutoff := 77
 	if countBefore != expectedBeforeCutoff {
 		t.Errorf("Expected %d entries before cutoff, got %d", expectedBeforeCutoff, countBefore)
 	}
 
-	// Test 3: Sanity check - find Geomys LLC entry with Review Pending (5/8/2025)
+	// Test 3: Sanity check - find Geomys LLC entry with Pending Review (4/25/2026)
 	foundGeomys := false
-	for _, entry := range reviewPendingEntries {
+	for _, entry := range pendingReviewEntries {
 		if entry.VendorName == "Geomys LLC" {
 			if entry.ModuleName != "Go Cryptographic Module" {
 				t.Errorf("Expected Geomys LLC module name 'Go Cryptographic Module', got '%s'", entry.ModuleName)
 			}
-			expectedDate := time.Date(2025, 5, 8, 0, 0, 0, 0, time.UTC)
+			expectedDate := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
 			if !entry.Date.Equal(expectedDate) {
-				t.Errorf("Expected Geomys LLC date to be 5/8/2025, got %s", entry.Date.Format("1/2/2006"))
+				t.Errorf("Expected Geomys LLC date to be 4/25/2026, got %s", entry.Date.Format("1/2/2006"))
 			}
 			if entry.Standard != "FIPS 140-3" {
 				t.Errorf("Expected Geomys LLC standard 'FIPS 140-3', got '%s'", entry.Standard)
@@ -69,7 +69,7 @@ func TestParseModulesInProcessList(t *testing.T) {
 	}
 
 	if !foundGeomys {
-		t.Error("Expected to find Geomys LLC entry with Review Pending status")
+		t.Error("Expected to find Geomys LLC entry with Pending Review status")
 	}
 }
 
@@ -82,31 +82,31 @@ func TestParseDateFunction(t *testing.T) {
 	}{
 		{
 			name:     "valid date format",
-			status:   "Review Pending (5/8/2025)",
-			expected: time.Date(2025, 5, 8, 0, 0, 0, 0, time.UTC),
+			status:   "Pending Review (4/25/2026)",
+			expected: time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
 			wantZero: false,
 		},
 		{
 			name:     "valid date with extra spaces",
-			status:   "Review Pending  (10/1/2024)",
+			status:   "Pending Review  (10/1/2024)",
 			expected: time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC),
 			wantZero: false,
 		},
 		{
 			name:     "invalid format - no parentheses",
-			status:   "Review Pending 5/8/2025",
+			status:   "Pending Review 4/25/2026",
 			expected: time.Time{},
 			wantZero: true,
 		},
 		{
 			name:     "invalid format - no date",
-			status:   "Review Pending",
+			status:   "Pending Review",
 			expected: time.Time{},
 			wantZero: true,
 		},
 		{
 			name:     "different status",
-			status:   "In Review (5/8/2025)",
+			status:   "In Review (4/25/2026)",
 			expected: time.Time{},
 			wantZero: true,
 		},
@@ -128,39 +128,39 @@ func TestParseDateFunction(t *testing.T) {
 	}
 }
 
-func TestFilterReviewPending(t *testing.T) {
+func TestFilterPendingReview(t *testing.T) {
 	entries := []ModuleEntry{
 		{
 			ModuleName: "Test Module 1",
 			VendorName: "Test Vendor 1",
 			Standard:   "FIPS 140-3",
-			Status:     "Review Pending (5/8/2025)",
-			Date:       time.Date(2025, 5, 8, 0, 0, 0, 0, time.UTC),
+			Status:     "Pending Review (4/25/2026)",
+			Date:       time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			ModuleName: "Test Module 2",
 			VendorName: "Test Vendor 2",
 			Standard:   "FIPS 140-3",
-			Status:     "In Review (4/1/2025)",
-			Date:       time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+			Status:     "In Review (4/1/2026)",
+			Date:       time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			ModuleName: "Test Module 3",
 			VendorName: "Test Vendor 3",
 			Standard:   "FIPS 140-3",
-			Status:     "Review Pending (3/1/2025)",
-			Date:       time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Status:     "Pending Review (3/1/2026)",
+			Date:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
 		},
 	}
 
-	filtered := filterReviewPending(entries)
+	filtered := filterPendingReview(entries)
 
 	if len(filtered) != 2 {
-		t.Errorf("Expected 2 Review Pending entries, got %d", len(filtered))
+		t.Errorf("Expected 2 Pending Review entries, got %d", len(filtered))
 	}
 
 	// Verify the correct entries were filtered
 	if filtered[0].ModuleName != "Test Module 1" || filtered[1].ModuleName != "Test Module 3" {
-		t.Error("Filtered entries don't match expected Review Pending entries")
+		t.Error("Filtered entries don't match expected Pending Review entries")
 	}
 }

--- a/mip/testdata/modules-in-process-list
+++ b/mip/testdata/modules-in-process-list
@@ -12,26 +12,26 @@
     <meta name="google-site-verification" content="xbrnrVYDgLD-Bd64xHLCt4XsPXzUhQ-4lGMj4TdUUTA" />
     
 
-	<meta name="description" content="The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Review Pending to In Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become..." />
+	<meta name="description" content="The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Pending Review to Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become..." />
 
 	<!-- dcterms meta information -->
 	<meta name="dcterms.title" content="Modules In Process List - Cryptographic Module Validation Program | CSRC | CSRC" />
-	<meta name="dcterms.description" content="The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Review Pending to In Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become..." />
+	<meta name="dcterms.description" content="The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Pending Review to Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become..." />
 	<meta name="dcterms.creator" content="Computer Security Division, Information Technology Laboratory, National Institute of Standards and Technology, U.S. Department of Commerce" />
 	<meta name="dcterms.date.created" scheme="ISO8601" content="2016-10-11" />
-	<meta name="dcterms.date.reviewed" scheme="ISO8601" content="2025-06-02" />
+	<meta name="dcterms.date.reviewed" scheme="ISO8601" content="2026-05-12" />
 	<meta name="dcterms.language" scheme="DCTERMS.RFC1766" content="EN-US" />
 
 	<!-- Facebook OpenGraph Tags -->
 	<meta name="og:site_name" content="CSRC | NIST" />
 	<meta name="og:type" content="article" />
-	<meta name="og:url" content="https://content.csrc.e1a.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list" />
+	<meta name="og:url" content="https://content.csrc.e1c.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List" />
 	<meta name="og:title" content="Modules In Process List - Cryptographic Module Validation Program | CSRC | CSRC" />
-	<meta name="og:description" content="The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Review Pending to In Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become available. The validation process is a joint effort between the CMVP, the laboratory and the vendor and therefore, for any given module, the action to respond could reside with the CMVP, the lab or the vendor. This list does not provide granularity into which entity has the action. The various circumstances that can trigger &#39;On Hold&#39; are stated in the FIPS 140-3 Management Manual, Section 4.3.4. For each submission, the status and the date it went into that state is listed. If you would like more information for a specific cryptographic module or its schedule, please contact the vendor. &#160;" />
+	<meta name="og:description" content="The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Pending Review to Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become available. The validation process is a joint effort between the CMVP, the laboratory and the vendor and therefore, for any given module, the action to respond could reside with the CMVP, the lab or the vendor. This list provides some granularity into which entity has the action. The various circumstances that can trigger &#39;Hold&#39; are stated in the FIPS 140-3 Management Manual, Section 4.3.4. For each submission, the status and the date it went into that state is listed. If you would like more information for a specific cryptographic module or its schedule, please contact the vendor. See&#160;Modules In Process&#160;page for additional details on the different module states.&#160; &#160;" />
 
 	<meta name="article:tag" content="cryptography; testing &amp; validation; hardware; software &amp; firmware" />
 	<meta name="article:published_time" content="2016-10-11" />
-		<meta name="article:modified_time" content="2025-06-02" />
+		<meta name="article:modified_time" content="2026-05-12" />
 
 
     <link rel="apple-touch-icon" sizes="180x180" href="/images/icons/apple-touch-icon.png" />
@@ -209,7 +209,7 @@
         <div class="row">
             <!-- Brand -->
             <div class="col-xs-6 col-md-4 navbar-header">
-                <a class="navbar-brand" href="https://www.nist.gov" target="_blank" id="navbar-brand-image">
+                <a class="navbar-brand" href="https://www.nist.gov" target='_blank' rel="noopener noreferrer" id="navbar-brand-image">
                     <img src="/CSRC/media/images/svg/nist-logo.svg" alt="National Institute of Standards and Technology" width="110" height="30">
                 </a>
             </div>
@@ -357,26 +357,27 @@
 </nav>
 
     <section id="itl-header" class="has-menu">
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-12 col-md-8">
-                    <div class="hidden-xs hidden-sm" id="itl-header-lg">
-                        <a href="https://www.nist.gov/itl" target="_blank" id="itl-header-link">Information Technology Laboratory</a>
+        <div class="itl-background"></div>
+            <div class="container">
+                <div class="row">
+                    <div class="col-sm-12 col-md-8">
+                        <div class="hidden-xs hidden-sm" id="itl-header-lg">
+                            <a href="https://www.nist.gov/itl" target='_blank' rel="noopener noreferrer" id="itl-header-link">Information Technology Laboratory</a>
+                        </div>
+                        <div class="hidden-xs hidden-sm" id="csrc-header-lg">
+                            <a href="/" id="csrc-header-link-lg">Computer Security Resource Center</a>
+                        </div>
                     </div>
-                    <div class="hidden-xs hidden-sm" id="csrc-header-lg">
-                        <a href="/" id="csrc-header-link-lg">Computer Security Resource Center</a>
-                    </div>
-                </div>
-                <div class="col-sm-12 col-md-4">
-                    <div class="hidden-xs hidden-sm hidden-md">
-                        <a id="logo-csrc-lg" href="/"><img id="img-logo-csrc-lg" src="/CSRC/Media/images/nist-logo-csrc-white.svg" alt="CSRC Logo" class="csrc-header-logo"></a>
-                    </div>
-                    <div class="hidden-lg">
-                        <a id="logo-csrc-sm" href="/"><img id="img-logo-csrc-sm" src="/CSRC/Media/images/nist-logo-csrc-white.svg" alt="CSRC Logo" class="csrc-header-logo"></a>
+                    <div class="col-sm-12 col-md-4">
+                        <div class="hidden-xs hidden-sm hidden-md">
+                            <a id="logo-csrc-lg" href="/"><img id="img-logo-csrc-lg" src="/CSRC/Media/images/nist-logo-csrc-white.svg" alt="CSRC Logo" class="csrc-header-logo"></a>
+                        </div>
+                        <div class="hidden-lg">
+                            <a id="logo-csrc-sm" href="/"><img id="img-logo-csrc-sm" src="/CSRC/Media/images/nist-logo-csrc-white.svg" alt="CSRC Logo" class="csrc-header-logo"></a>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
     </section>
 
     <div id="body-section" class="container">
@@ -399,7 +400,7 @@
     <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcsrc.nist.gov%2Fprojects%2Fcryptographic-module-validation-program%2Fmodules-in-process%2Fmodules-in-process-list" class="social-facebook"><i class="fa fa-facebook fa-fw" aria-hidden="true"></i><span class="sr-only">Share to Facebook</span></a>
     <a href="https://x.com/share?url=https%3A%2F%2Fcsrc.nist.gov%2Fprojects%2Fcryptographic-module-validation-program%2Fmodules-in-process%2Fmodules-in-process-list" class="social-twitter"><i class="fa-brands fa-x-twitter"></i><span class="sr-only">Share to X</span></a>
     <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https%3A%2F%2Fcsrc.nist.gov%2Fprojects%2Fcryptographic-module-validation-program%2Fmodules-in-process%2Fmodules-in-process-list&amp;source=csrc.nist.gov" class="social-linked-in"><i class="fa fa-linkedin fa-fw" aria-hidden="true"></i><span class="sr-only">Share to LinkedIn</span></a>
-    <a href="/cdn-cgi/l/email-protection#d0efa3a5b2bab5b3a4edb3a3a2b3febeb9a3a4feb7bfa6f6b1bda0ebb2bfb4a9ed93b8b5b3bbf0bfa5a4f0a4b8b9a3f0a3b9a4b5f0b8a4a4a0a3eaffffb3a3a2b3febeb9a3a4feb7bfa6ff80a2bfbab5b3a4a3ffb3a2a9a0a4bfb7a2b1a0b8b9b3fdbdbfb4a5bcb5fda6b1bcb9b4b1a4b9bfbefda0a2bfb7a2b1bdffbdbfb4a5bcb5a3fdb9befda0a2bfb3b5a3a3ffbdbfb4a5bcb5a3fdb9befda0a2bfb3b5a3a3fdbcb9a3a4" class="social-email"><i class="fa fa-envelope fa-fw" aria-hidden="true"></i><span class="sr-only">Share ia Email</span></a>
+    <a href="/cdn-cgi/l/email-protection#4b74383e29212e283f7628383928652522383f652c243d6d2a263b7029242f327608232e28206b243e3f6b3f2322386b38223f2e6b233f3f3b3871646428383928652522383f652c243d641b3924212e283f38642839323b3f242c392a3b2322286626242f3e272e663d2a27222f2a3f222425663b39242c392a266426242f3e272e38662225663b3924282e38386406242f3e272e38660225661b3924282e3838660722383f" class="social-email"><i class="fa fa-envelope fa-fw" aria-hidden="true"></i><span class="sr-only">Share ia Email</span></a>
 </div>
 
 
@@ -442,12 +443,12 @@
 
 
 		<p id="content">
-			The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Review Pending to In Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become available. The validation process is a joint effort between the CMVP, the laboratory and the vendor and therefore, for any given module, the action to respond could reside with the CMVP, the lab or the vendor. This list does not provide granularity into which entity has the action. The various circumstances that can trigger "On Hold" are stated in the <a href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/cmvp-fips-140-3-management-manual">FIPS 140-3 Management Manual</a>, Section 4.3.4. For each submission, the status and the date it went into that state is listed. If you would like more information for a specific cryptographic module or its schedule, please contact the vendor.<br>
+			The MIP list contains cryptographic modules on which the CMVP is actively working on. For a module to transition from Pending Review to Review, the lab must first pay the NIST Cost Recovery fee, and then the report will be assigned as resources become available. The validation process is a joint effort between the CMVP, the laboratory and the vendor and therefore, for any given module, the action to respond could reside with the CMVP, the lab or the vendor. This list provides some granularity into which entity has the action. The various circumstances that can trigger "Hold" are stated in the <a href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/cmvp-fips-140-3-management-manual">FIPS 140-3 Management Manual</a>, Section 4.3.4. For each submission, the status and the date it went into that state is listed. If you would like more information for a specific cryptographic module or its schedule, please contact the vendor. See&nbsp;<a data-csrc-link="true" data-node-guid="0431d6de-c342-4c34-b3b4-a0c928bb0547" href="/projects/cryptographic-module-validation-program/modules-in-process">Modules In Process</a>&nbsp;page for additional details on the different module states.&nbsp;<br>
 &nbsp;
 		</p>
 
 			<p>
-				Last Updated: 6/12/2025
+				Last Updated: 5/27/2026
 			</p>
 			<table class="table table-striped table-condensed publications-table table-bordered">
 				<thead>
@@ -460,16 +461,52 @@
 				</thead>
 				<tbody>
 						<tr>
-							<td>AMD ASP Cryptographic CoProcessor ("Turin")</td>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM9D3a Series</td>
 							<td>
-								Advanced Micro Devices (AMD)
-									<a class="btn" role="button" data-toggle="collapse" id="a13086" href="#d13086" onclick="ShowContacts(13086)">
-										<i id="i13086" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								 Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13624" href="#d13624" onclick="ShowContacts(13624)">
+										<i id="i13624" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13086" class="collapse"></div>
+									<div id="d13624" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/1/2024)</td>
+							<td class="nowrap">Pending Review  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM9D3a Series</td>
+							<td>
+								 Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13614" href="#d13614" onclick="ShowContacts(13614)">
+										<i id="i13614" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13614" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/21/2026)</td>
+						</tr>
+						<tr>
+							<td>AMD ASP Cryptographic CoProcessor ("Granite Ridge")</td>
+							<td>
+								Advanced Micro Devices (AMD)
+									<a class="btn" role="button" data-toggle="collapse" id="a13776" href="#d13776" onclick="ShowContacts(13776)">
+										<i id="i13776" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13776" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Cost Recovery  (5/19/2026)</td>
+						</tr>
+						<tr>
+							<td>AMD ASP Cryptographic CoProcessor ("Phoenix2")</td>
+							<td>
+								Advanced Micro Devices (AMD)
+									<a class="btn" role="button" data-toggle="collapse" id="a13775" href="#d13775" onclick="ShowContacts(13775)">
+										<i id="i13775" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13775" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Cost Recovery  (5/19/2026)</td>
 						</tr>
 						<tr>
 							<td>AWS Nitro Card Security Engine SSMAE</td>
@@ -481,10 +518,34 @@
 									<div id="d13071" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/22/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/20/2026)</td>
 						</tr>
 						<tr>
-							<td>AWS-LC 3.0 Cryptographic Module (dynamic)</td>
+							<td>AWS-LC 4.0 Cryptographic Module (dynamic)</td>
+							<td>
+								Amazon Web Services Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13708" href="#d13708" onclick="ShowContacts(13708)">
+										<i id="i13708" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13708" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/7/2026)</td>
+						</tr>
+						<tr>
+							<td>AWS-LC Cryptographic Module (dynamic)</td>
+							<td>
+								Amazon Web Services Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/16/2026)</td>
+						</tr>
+						<tr>
+							<td>AWS-LC 3 Cryptographic Module (dynamic)</td>
 							<td>
 								Amazon Web Services, Inc
 									<a class="btn" role="button" data-toggle="collapse" id="a13177" href="#d13177" onclick="ShowContacts(13177)">
@@ -493,10 +554,10 @@
 									<div id="d13177" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/5/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/20/2026)</td>
 						</tr>
 						<tr>
-							<td>AWS-LC 3.0 Cryptographic Module (static)</td>
+							<td>AWS-LC 3 Cryptographic Module (static)</td>
 							<td>
 								Amazon Web Services, Inc
 									<a class="btn" role="button" data-toggle="collapse" id="a13179" href="#d13179" onclick="ShowContacts(13179)">
@@ -505,91 +566,103 @@
 									<div id="d13179" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/6/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/13/2026)</td>
 						</tr>
 						<tr>
-							<td>AWS-LC Cryptographic Module (dynamic)</td>
-							<td>
-								Amazon Web Services, Inc
-									<a class="btn" role="button" data-toggle="collapse" id="a13039" href="#d13039" onclick="ShowContacts(13039)">
-										<i id="i13039" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13039" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/29/2024)</td>
-						</tr>
-						<tr>
-							<td>AWS Encryption Module</td>
+							<td>Amazon Linux 2023 GnuTLS Cryptographic Module</td>
 							<td>
 								Amazon Web Services, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12679" href="#d12679" onclick="ShowContacts(12679)">
-										<i id="i12679" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13483" href="#d13483" onclick="ShowContacts(13483)">
+										<i id="i13483" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12679" class="collapse"></div>
+									<div id="d13483" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/6/2024)</td>
+							<td class="nowrap">Pending Review  (3/10/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module 18.3 [Apple silicon, User, Software, SL1]</td>
+							<td>Amazon Linux 2023 Kernel Cryptographic API</td>
 							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13201" href="#d13201" onclick="ShowContacts(13201)">
-										<i id="i13201" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Amazon Web Services, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13201" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/29/2025)</td>
+							<td class="nowrap">Review  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v12.0 [Apple silicon, Secure Key Store, Hardware, SL2/PHY3] </td>
+							<td>Amazon Linux 2023 OpenSSL FIPS Provider</td>
 							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12355" href="#d12355" onclick="ShowContacts(12355)">
-										<i id="i12355" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Amazon Web Services, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13484" href="#d13484" onclick="ShowContacts(13484)">
+										<i id="i13484" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12355" class="collapse"></div>
+									<div id="d13484" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/11/2025)</td>
+							<td class="nowrap">Pending Review  (3/10/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v12.0 [Apple silicon, Secure Key Store, Hardware, SL2] </td>
+							<td>AWS Scalable Network Crypto Modules, version 1.1</td>
 							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12354" href="#d12354" onclick="ShowContacts(12354)">
-										<i id="i12354" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Amazon Web Services, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13564" href="#d13564" onclick="ShowContacts(13564)">
+										<i id="i13564" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12354" class="collapse"></div>
+									<div id="d13564" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (5/13/2025)</td>
+							<td class="nowrap">Review  (5/13/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v13.0 [Apple silicon, Kernel, Software, SL1]</td>
+							<td>AWS-LC Cryptographic Module (static)</td>
 							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12503" href="#d12503" onclick="ShowContacts(12503)">
-										<i id="i12503" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Amazon Web Services, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13709" href="#d13709" onclick="ShowContacts(13709)">
+										<i id="i13709" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12503" class="collapse"></div>
+									<div id="d13709" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/10/2025)</td>
+							<td class="nowrap">Pending Review  (5/7/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v13.0 [Apple silicon, Secure Key Store, Hardware SL2/PHY3]</td>
+							<td>Apple corecrypto Module 18.3 [Apple silicon, Kernel, Software, SL1]</td>
 							<td>
 								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13053" href="#d13053" onclick="ShowContacts(13053)">
-										<i id="i13053" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13200" href="#d13200" onclick="ShowContacts(13200)">
+										<i id="i13200" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13053" class="collapse"></div>
+									<div id="d13200" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/27/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/30/2026)</td>
+						</tr>
+						<tr>
+							<td>Apple corecrypto Module 18.3 [Apple silicon, Secure Key Store, Hardware, SL2/PHY3]</td>
+							<td>
+								Apple Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13202" href="#d13202" onclick="ShowContacts(13202)">
+										<i id="i13202" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13202" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/26/2026)</td>
+						</tr>
+						<tr>
+							<td>Apple corecrypto Module 18.3 [Apple silicon, Secure Key Store, Hardware, SL2/PHY3]</td>
+							<td>
+								Apple Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13549" href="#d13549" onclick="ShowContacts(13549)">
+										<i id="i13549" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13549" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/26/2026)</td>
 						</tr>
 						<tr>
 							<td>Apple corecrypto Module v13.0 [Apple silicon, Secure Key Store, Hardware SL2]</td>
@@ -601,31 +674,31 @@
 									<div id="d13052" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/27/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v13.0 [Apple silicon, User, Software, SL1]</td>
+							<td>Apple corecrypto Module v13.0 [Intel, Kernel, Software, SL1]</td>
 							<td>
 								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12502" href="#d12502" onclick="ShowContacts(12502)">
-										<i id="i12502" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12502" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (4/28/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v14.0 [Apple silicon, Kernel, Software, SL1]</td>
+							<td>Apple corecrypto Module v13.0 [Intel, User, Software, SL1]</td>
 							<td>
 								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13306" href="#d13306" onclick="ShowContacts(13306)">
-										<i id="i13306" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13306" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/7/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
 						</tr>
 						<tr>
 							<td>Apple corecrypto Module v14.0 [Apple silicon, Secure Key Store, Hardware, SL2/PHY3]</td>
@@ -637,7 +710,7 @@
 									<div id="d13407" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/23/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/27/2026)</td>
 						</tr>
 						<tr>
 							<td>Apple corecrypto Module v14.0 [Apple silicon, Secure Key Store, Hardware, SL2]</td>
@@ -649,79 +722,103 @@
 									<div id="d13406" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/23/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/27/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v14.0 [Apple silicon, User, Software, SL1]</td>
+							<td>Aegis Secure Key 3.0 Cryptographic Module</td>
 							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13305" href="#d13305" onclick="ShowContacts(13305)">
-										<i id="i13305" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Apricorn
+									<a class="btn" role="button" data-toggle="collapse" id="a13134" href="#d13134" onclick="ShowContacts(13134)">
+										<i id="i13134" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13305" class="collapse"></div>
+									<div id="d13134" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/6/2025)</td>
+							<td class="nowrap">Pending Review  (4/14/2026)</td>
 						</tr>
 						<tr>
-							<td>Apple corecrypto Module v14.0 [Intel, Kernel, Software, SL1]</td>
-							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12881" href="#d12881" onclick="ShowContacts(12881)">
-										<i id="i12881" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12881" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/24/2025)</td>
-						</tr>
-						<tr>
-							<td>Apple corecrypto Module v14.0 [Intel, User, Software, SL1]</td>
-							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12882" href="#d12882" onclick="ShowContacts(12882)">
-										<i id="i12882" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12882" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/24/2025)</td>
-						</tr>
-						<tr>
-							<td>Apple corecrypto Module v14.1 [Apple silicon, Kernel, Software, SL1]</td>
-							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13042" href="#d13042" onclick="ShowContacts(13042)">
-										<i id="i13042" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13042" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/3/2024)</td>
-						</tr>
-						<tr>
-							<td>Apple corecrypto Module v14.1 [Apple silicon, User, Software, SL1]</td>
-							<td>
-								Apple Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13041" href="#d13041" onclick="ShowContacts(13041)">
-										<i id="i13041" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13041" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/3/2024)</td>
-						</tr>
-						<tr>
-							<td>Arista Crypto Module Lvl2 [Software, Software IPsec]</td>
+							<td>Arista Crypto Module v3.0 [Software, Software IPsec, Web Portal]</td>
 							<td>
 								Arista Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12757" href="#d12757" onclick="ShowContacts(12757)">
-										<i id="i12757" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12757" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (4/23/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/9/2026)</td>
+						</tr>
+						<tr>
+							<td>Arista Crypto Module v3.0 [Software, Software IPsec]</td>
+							<td>
+								Arista Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/9/2026)</td>
+						</tr>
+						<tr>
+							<td>Arista MACsec data plane accelerator [on-chip]</td>
+							<td>
+								Arista Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13163" href="#d13163" onclick="ShowContacts(13163)">
+										<i id="i13163" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13163" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
+						</tr>
+						<tr>
+							<td>Arista MACsec data plane accelerator [on-chip-driver]</td>
+							<td>
+								Arista Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13351" href="#d13351" onclick="ShowContacts(13351)">
+										<i id="i13351" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13351" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/14/2026)</td>
+						</tr>
+						<tr>
+							<td>Arista MACsec data plane accelerator [PHY] </td>
+							<td>
+								Arista Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13162" href="#d13162" onclick="ShowContacts(13162)">
+										<i id="i13162" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13162" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>Arista WiFi Access Points</td>
+							<td>
+								Arista Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13557" href="#d13557" onclick="ShowContacts(13557)">
+										<i id="i13557" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13557" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/14/2026)</td>
+						</tr>
+						<tr>
+							<td>AC8025 HSM </td>
+							<td>
+								AutoChips Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13176" href="#d13176" onclick="ShowContacts(13176)">
+										<i id="i13176" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13176" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/11/2026)</td>
 						</tr>
 						<tr>
 							<td>Aviat Networks Eclipse Cryptographic Module</td>
@@ -733,10 +830,10 @@
 									<div id="d13222" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/20/2025)</td>
+							<td class="nowrap">Pending Resubmission  (11/13/2025)</td>
 						</tr>
 						<tr>
-							<td>Aviat Networks WTM4000 Cryptographic Module</td>
+							<td>Aviat Networks WTM 4100/4200/4500/4500XT Payload Encryption Module</td>
 							<td>
 								Aviat Networks, Inc.
 									<a class="btn" role="button" data-toggle="collapse" id="a13040" href="#d13040" onclick="ShowContacts(13040)">
@@ -745,7 +842,7 @@
 									<div id="d13040" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/30/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (2/17/2026)</td>
 						</tr>
 						<tr>
 							<td>Barco ICMP-XS Cryptographic Module</td>
@@ -757,7 +854,31 @@
 									<div id="d13046" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/5/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/9/2026)</td>
+						</tr>
+						<tr>
+							<td>TASS Crypto Engine</td>
+							<td>
+								Beijing JN TASS Technology Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13725" href="#d13725" onclick="ShowContacts(13725)">
+										<i id="i13725" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13725" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/4/2026)</td>
+						</tr>
+						<tr>
+							<td>Security Builder FIPS Module</td>
+							<td>
+								Blackberry Limited
+									<a class="btn" role="button" data-toggle="collapse" id="a13373" href="#d13373" onclick="ShowContacts(13373)">
+										<i id="i13373" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13373" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/4/2026)</td>
 						</tr>
 						<tr>
 							<td>PTP 700 Point to Point Wireless Ethernet Bridge</td>
@@ -769,55 +890,91 @@
 									<div id="d13356" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/16/2025)</td>
+							<td class="nowrap">Pending Review  (5/15/2025)</td>
 						</tr>
 						<tr>
-							<td>Canonical Ltd. Ubuntu 24.04 GnuTLS Cryptographic Module</td>
+							<td>Canonical Ltd. Ubuntu 22.04 GnuTLS Cryptographic Module</td>
 							<td>
 								Canonical Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12999" href="#d12999" onclick="ShowContacts(12999)">
-										<i id="i12999" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12999" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/19/2024)</td>
+							<td class="nowrap">Pending Review  (3/20/2026)</td>
 						</tr>
 						<tr>
-							<td>Canonical Ltd. Ubuntu 24.04 OpenSSL Cryptographic Module</td>
+							<td>Canonical Ltd. Ubuntu 22.04 Kernel Crypto API Cryptographic Module</td>
 							<td>
 								Canonical Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12998" href="#d12998" onclick="ShowContacts(12998)">
-										<i id="i12998" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12998" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/19/2024)</td>
+							<td class="nowrap">Pending Review  (2/5/2026)</td>
+						</tr>
+						<tr>
+							<td>Canonical Ltd. Ubuntu 22.04 Libgcrypt Cryptographic Module</td>
+							<td>
+								Canonical Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/19/2026)</td>
+						</tr>
+						<tr>
+							<td>Canonical Ltd. Ubuntu 22.04 OpenSSL Cryptographic Module</td>
+							<td>
+								Canonical Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/11/2026)</td>
+						</tr>
+						<tr>
+							<td>Canonical Ltd. Ubuntu 22.04 Strongswan Cryptographic Module</td>
+							<td>
+								Canonical Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/17/2026)</td>
 						</tr>
 						<tr>
 							<td>Chainguard FIPS Provider for OpenSSL</td>
 							<td>
 								Chainguard, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12933" href="#d12933" onclick="ShowContacts(12933)">
-										<i id="i12933" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13608" href="#d13608" onclick="ShowContacts(13608)">
+										<i id="i13608" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12933" class="collapse"></div>
+									<div id="d13608" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/18/2025)</td>
+							<td class="nowrap">Pending Resubmission  (5/5/2026)</td>
 						</tr>
 						<tr>
-							<td>Christie IMB-S4 4K Integrated Media Block (IMB)</td>
+							<td>HiCOS PKI Applet V4 on IDEMIA ID-One Cosmo X</td>
 							<td>
-								Christie Digital Systems Canada Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12751" href="#d12751" onclick="ShowContacts(12751)">
-										<i id="i12751" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Chunghwa Telecom Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13716" href="#d13716" onclick="ShowContacts(13716)">
+										<i id="i13716" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12751" class="collapse"></div>
+									<div id="d13716" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/2/2025)</td>
+							<td class="nowrap">Pending Review  (3/10/2026)</td>
 						</tr>
 						<tr>
 							<td>HiPKI SafGuard 2000 HSM</td>
@@ -829,7 +986,7 @@
 									<div id="d12733" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/29/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
 						</tr>
 						<tr>
 							<td>Ciena Waveserver Ai WCS-2</td>
@@ -841,7 +998,31 @@
 									<div id="d13313" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/11/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/27/2026)</td>
+						</tr>
+						<tr>
+							<td>WaveLogic 5 Extreme Encryption Modem</td>
+							<td>
+								Ciena Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13377" href="#d13377" onclick="ShowContacts(13377)">
+										<i id="i13377" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13377" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/24/2026)</td>
+						</tr>
+						<tr>
+							<td>Waveserver 5 Control Processor Module</td>
+							<td>
+								Ciena Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13378" href="#d13378" onclick="ShowContacts(13378)">
+										<i id="i13378" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13378" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/24/2026)</td>
 						</tr>
 						<tr>
 							<td>Waveserver Ai Encryption Module</td>
@@ -853,7 +1034,7 @@
 									<div id="d12850" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/11/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/27/2026)</td>
 						</tr>
 						<tr>
 							<td>CiscoSSL FIPS Provider</td>
@@ -865,43 +1046,43 @@
 									<div id="d13119" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/5/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
 						</tr>
 						<tr>
-							<td> Firepower Threat Defense Virtual Cryptographic Module </td>
+							<td>CiscoSSL FIPS Provider</td>
 							<td>
 								Cisco Systems, Inc
-									<a class="btn" role="button" data-toggle="collapse" id="a13150" href="#d13150" onclick="ShowContacts(13150)">
-										<i id="i13150" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13150" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/26/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>Firepower Management Center Virtual Cryptographic Module </td>
+							<td>Firepower Management Center Virtual VMware Cryptographic Module</td>
 							<td>
 								Cisco Systems, Inc
-									<a class="btn" role="button" data-toggle="collapse" id="a13151" href="#d13151" onclick="ShowContacts(13151)">
-										<i id="i13151" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13151" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/6/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/11/2026)</td>
 						</tr>
 						<tr>
-							<td>Adaptive Security Appliance Virtual Cryptographic Module</td>
+							<td>Cisco 8200 Series Routers</td>
 							<td>
 								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13149" href="#d13149" onclick="ShowContacts(13149)">
-										<i id="i13149" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13315" href="#d13315" onclick="ShowContacts(13315)">
+										<i id="i13315" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13149" class="collapse"></div>
+									<div id="d13315" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/25/2024)</td>
+							<td class="nowrap">Review  (5/19/2026)</td>
 						</tr>
 						<tr>
 							<td>Cisco 8800 Series Routers with MACsec</td>
@@ -913,7 +1094,7 @@
 									<div id="d13231" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/7/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (1/29/2026)</td>
 						</tr>
 						<tr>
 							<td>Cisco 8800 Series Routers without MACsec</td>
@@ -925,55 +1106,7 @@
 									<div id="d13276" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/7/2025)</td>
-						</tr>
-						<tr>
-							<td>Cisco Adaptive Security Appliance Cryptographic Module (FPR 1000 Series)</td>
-							<td>
-								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12812" href="#d12812" onclick="ShowContacts(12812)">
-										<i id="i12812" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12812" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/2/2024)</td>
-						</tr>
-						<tr>
-							<td>Cisco Adaptive Security Appliance Cryptographic Module (FPR 2100 Series)</td>
-							<td>
-								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12669" href="#d12669" onclick="ShowContacts(12669)">
-										<i id="i12669" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12669" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/26/2024)</td>
-						</tr>
-						<tr>
-							<td>Cisco Adaptive Security Appliance Cryptographic Module (FPR 4200 Series)</td>
-							<td>
-								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12996" href="#d12996" onclick="ShowContacts(12996)">
-										<i id="i12996" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12996" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/19/2024)</td>
-						</tr>
-						<tr>
-							<td>Cisco Adaptive Security Appliance on 4K/9K Cryptographic Module</td>
-							<td>
-								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12818" href="#d12818" onclick="ShowContacts(12818)">
-										<i id="i12818" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12818" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/25/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (1/29/2026)</td>
 						</tr>
 						<tr>
 							<td>Cisco ASA FX-OS on 4K/9K Cryptographic Module</td>
@@ -985,7 +1118,7 @@
 									<div id="d12819" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/13/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/29/2025)</td>
 						</tr>
 						<tr>
 							<td>Cisco Firepower Threat Defense on 4K/9K Cryptographic Module</td>
@@ -997,7 +1130,7 @@
 									<div id="d12816" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/25/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/29/2025)</td>
 						</tr>
 						<tr>
 							<td>Cisco FTD FX-OS on 4K/9K Cryptographic Module</td>
@@ -1009,91 +1142,211 @@
 									<div id="d12817" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/13/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/29/2025)</td>
 						</tr>
 						<tr>
-							<td>Cisco Secure Firewall Threat Defense Cryptographic Module (FPR 1000 Series)</td>
+							<td>Firepower Next-Generation IPS Virtual VMware Cryptographic Module</td>
 							<td>
 								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12813" href="#d12813" onclick="ShowContacts(12813)">
-										<i id="i12813" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12813" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/7/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/11/2026)</td>
 						</tr>
 						<tr>
-							<td>Cisco Secure Firewall Threat Defense Cryptographic Module (FPR 2100 Series)</td>
+							<td>Firepower Threat Defense Virtual Cryptographic Module</td>
 							<td>
 								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12814" href="#d12814" onclick="ShowContacts(12814)">
-										<i id="i12814" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12814" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/26/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/1/2026)</td>
 						</tr>
 						<tr>
-							<td>Cisco Secure Firewall Threat Defense Cryptographic Module (FPR 4200 Series)</td>
+							<td>IOS Common Cryptographic Module (IC2M)</td>
 							<td>
 								Cisco Systems, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12997" href="#d12997" onclick="ShowContacts(12997)">
-										<i id="i12997" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12997" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/19/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>NetScaler Virtual Appliance</td>
+							<td>Citrix FIPS Cryptographic Module</td>
+							<td>
+								Citrix Systems, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13286" href="#d13286" onclick="ShowContacts(13286)">
+										<i id="i13286" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13286" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>TuxCare GnuTLS Cryptographic Module</td>
+							<td>
+								Cloud Linux Software, Inc. d/b/a TuxCare
+									<a class="btn" role="button" data-toggle="collapse" id="a13249" href="#d13249" onclick="ShowContacts(13249)">
+										<i id="i13249" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13249" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
+						</tr>
+						<tr>
+							<td>TuxCare Kernel Crypto API</td>
+							<td>
+								Cloud Linux Software, Inc. d/b/a TuxCare
+									<a class="btn" role="button" data-toggle="collapse" id="a13247" href="#d13247" onclick="ShowContacts(13247)">
+										<i id="i13247" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13247" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/30/2026)</td>
+						</tr>
+						<tr>
+							<td>TuxCare NSS Cryptographic Module</td>
+							<td>
+								Cloud Linux Software, Inc. d/b/a TuxCare
+									<a class="btn" role="button" data-toggle="collapse" id="a13248" href="#d13248" onclick="ShowContacts(13248)">
+										<i id="i13248" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13248" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/30/2026)</td>
+						</tr>
+						<tr>
+							<td>TuxCare OpenSSL FIPS Provider</td>
+							<td>
+								Cloud Linux Software, Inc. d/b/a TuxCare
+									<a class="btn" role="button" data-toggle="collapse" id="a13246" href="#d13246" onclick="ShowContacts(13246)">
+										<i id="i13246" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13246" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/1/2026)</td>
+						</tr>
+						<tr>
+							<td>NetScaler MPX</td>
 							<td>
 								Cloud Software Group
-									<a class="btn" role="button" data-toggle="collapse" id="a12912" href="#d12912" onclick="ShowContacts(12912)">
-										<i id="i12912" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13293" href="#d13293" onclick="ShowContacts(13293)">
+										<i id="i13293" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12912" class="collapse"></div>
+									<div id="d13293" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">In Review  (5/22/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/14/2026)</td>
 						</tr>
 						<tr>
-							<td>GnuTLS cryptography module for AlmaLinux 9</td>
+							<td>NetScaler MPX</td>
 							<td>
-								Cloudlinux Inc., TuxCare division
-									<a class="btn" role="button" data-toggle="collapse" id="a12789" href="#d12789" onclick="ShowContacts(12789)">
-										<i id="i12789" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Cloud Software Group
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12789" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">In Review  (5/8/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/15/2026)</td>
 						</tr>
 						<tr>
-							<td>Libgcrypt cryptography module for AlmaLinux 9</td>
+							<td>NetScaler VPX</td>
 							<td>
-								Cloudlinux Inc., TuxCare division
-									<a class="btn" role="button" data-toggle="collapse" id="a12787" href="#d12787" onclick="ShowContacts(12787)">
-										<i id="i12787" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Cloud Software Group
+									<a class="btn" role="button" data-toggle="collapse" id="a13546" href="#d13546" onclick="ShowContacts(13546)">
+										<i id="i13546" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12787" class="collapse"></div>
+									<div id="d13546" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/17/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
 						</tr>
 						<tr>
-							<td>NSS cryptography module for AlmaLinux 9</td>
+							<td>OpenSSL FIPS Provider for AlmaLinux 9</td>
 							<td>
 								Cloudlinux Inc., TuxCare division
-									<a class="btn" role="button" data-toggle="collapse" id="a12788" href="#d12788" onclick="ShowContacts(12788)">
-										<i id="i12788" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12788" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/11/2025)</td>
+							<td class="nowrap">Pending Review  (4/10/2026)</td>
+						</tr>
+						<tr>
+							<td>MESH SDR Cryptography Module</td>
+							<td>
+								Codan DTC
+									<a class="btn" role="button" data-toggle="collapse" id="a13033" href="#d13033" onclick="ShowContacts(13033)">
+										<i id="i13033" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13033" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/26/2026)</td>
+						</tr>
+						<tr>
+							<td>Code Siren Post-Quantum Cryptographic (PQC) Library for Desktop</td>
+							<td>
+								Code Siren, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13675" href="#d13675" onclick="ShowContacts(13675)">
+										<i id="i13675" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13675" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/13/2026)</td>
+						</tr>
+						<tr>
+							<td>Code Siren Post-Quantum Cryptographic (PQC) Library for Mobile</td>
+							<td>
+								Code Siren, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13676" href="#d13676" onclick="ShowContacts(13676)">
+										<i id="i13676" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13676" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/19/2026)</td>
+						</tr>
+						<tr>
+							<td>Port Authority Series </td>
+							<td>
+								Communication Devices Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/15/2026)</td>
+						</tr>
+						<tr>
+							<td>CorSSL</td>
+							<td>
+								Corsec Security, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13669" href="#d13669" onclick="ShowContacts(13669)">
+										<i id="i13669" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13669" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
 						</tr>
 						<tr>
 							<td>QASM Cryptographic Module</td>
@@ -1105,7 +1358,7 @@
 									<div id="d12983" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/19/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/25/2026)</td>
 						</tr>
 						<tr>
 							<td>Rocky Linux 8 and 9 GnuTLS Cryptographic Module</td>
@@ -1117,19 +1370,7 @@
 									<div id="d13078" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/31/2025)</td>
-						</tr>
-						<tr>
-							<td>Rocky Linux 8 and 9 libgcrypt Cryptographic Module</td>
-							<td>
-								Ctrl IQ, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13077" href="#d13077" onclick="ShowContacts(13077)">
-										<i id="i13077" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13077" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/17/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/18/2026)</td>
 						</tr>
 						<tr>
 							<td>Rocky Linux 8 and 9 NSS Cryptographic Module</td>
@@ -1141,91 +1382,139 @@
 									<div id="d13080" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/13/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/27/2026)</td>
 						</tr>
 						<tr>
-							<td>Rocky Linux 8 Kernel Cryptographic API</td>
+							<td>Rocky Linux 9 GnuTLS Cryptographic Module</td>
 							<td>
 								Ctrl IQ, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13079" href="#d13079" onclick="ShowContacts(13079)">
-										<i id="i13079" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13541" href="#d13541" onclick="ShowContacts(13541)">
+										<i id="i13541" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13079" class="collapse"></div>
+									<div id="d13541" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/3/2024)</td>
-						</tr>
-						<tr>
-							<td>Rocky Linux 8 OpenSSL Cryptographic Module</td>
-							<td>
-								Ctrl IQ, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13076" href="#d13076" onclick="ShowContacts(13076)">
-										<i id="i13076" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13076" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/30/2025)</td>
+							<td class="nowrap">Review  (5/6/2026)</td>
 						</tr>
 						<tr>
 							<td>Rocky Linux 9 Kernel Cryptographic API</td>
 							<td>
 								Ctrl IQ, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13281" href="#d13281" onclick="ShowContacts(13281)">
-										<i id="i13281" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13540" href="#d13540" onclick="ShowContacts(13540)">
+										<i id="i13540" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13281" class="collapse"></div>
+									<div id="d13540" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/27/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/30/2026)</td>
 						</tr>
 						<tr>
-							<td>Rocky Linux 9 OpenSSL FIPS Provider</td>
+							<td>Rocky Linux 9 NSS Cryptographic Module</td>
 							<td>
 								Ctrl IQ, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13075" href="#d13075" onclick="ShowContacts(13075)">
-										<i id="i13075" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13542" href="#d13542" onclick="ShowContacts(13542)">
+										<i id="i13542" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13075" class="collapse"></div>
+									<div id="d13542" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/25/2025)</td>
+							<td class="nowrap">Pending Review  (2/6/2026)</td>
 						</tr>
 						<tr>
-							<td>DL4FE</td>
+							<td>Stinger Encryption Module</td>
 							<td>
-								DataLocker, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12803" href="#d12803" onclick="ShowContacts(12803)">
-										<i id="i12803" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Datum Systems, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13672" href="#d13672" onclick="ShowContacts(13672)">
+										<i id="i13672" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12803" class="collapse"></div>
+									<div id="d13672" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/7/2024)</td>
+							<td class="nowrap">Pending Resubmission  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>K350</td>
+							<td>Dell BSAFE Crypto Module for Java</td>
 							<td>
-								DataLocker, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12802" href="#d12802" onclick="ShowContacts(12802)">
-										<i id="i12802" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Dell Australia Pty Limited, BSAFE Product Team
+									<a class="btn" role="button" data-toggle="collapse" id="a12953" href="#d12953" onclick="ShowContacts(12953)">
+										<i id="i12953" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12802" class="collapse"></div>
+									<div id="d12953" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/14/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Dell BSAFE™ Crypto Module for C</td>
+							<td>
+								Dell Australia Pty Limited, BSAFE Product Team
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/31/2026)</td>
+						</tr>
+						<tr>
+							<td>Dell BSAFE Crypto Module for Java</td>
+							<td>
+								Dell Inc., BSAFE Product Team
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/26/2026)</td>
+						</tr>
+						<tr>
+							<td>DigiCert TrustCore Cryptographic Loadable Kernel Module</td>
+							<td>
+								DigiCert, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/13/2026)</td>
 						</tr>
 						<tr>
 							<td>DigiCert TrustCore Cryptographic Suite B Module</td>
 							<td>
 								DigiCert, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13199" href="#d13199" onclick="ShowContacts(13199)">
-										<i id="i13199" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13199" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/17/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/13/2026)</td>
+						</tr>
+						<tr>
+							<td>TM400ENB</td>
+							<td>
+								ECI Telecom Ltd / Ribbon communications Operating company, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13311" href="#d13311" onclick="ShowContacts(13311)">
+										<i id="i13311" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13311" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/31/2026)</td>
+						</tr>
+						<tr>
+							<td>nShield 5s Hardware Security Module</td>
+							<td>
+								Entrust
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/15/2026)</td>
 						</tr>
 						<tr>
 							<td>Taming Sari Crypto Module v1.0</td>
@@ -1237,79 +1526,115 @@
 									<div id="d13178" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/5/2024)</td>
+							<td class="nowrap">Finalization  (5/19/2026)</td>
 						</tr>
 						<tr>
-							<td>Summit Linux FIPS Core Crypto Module</td>
+							<td>BIG-IP Tenant Cryptographic Module</td>
 							<td>
-								Ezurio
-									<a class="btn" role="button" data-toggle="collapse" id="a12826" href="#d12826" onclick="ShowContacts(12826)">
-										<i id="i12826" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								F5, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13402" href="#d13402" onclick="ShowContacts(13402)">
+										<i id="i13402" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12826" class="collapse"></div>
+									<div id="d13402" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">In Review  (4/22/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
 						</tr>
 						<tr>
-							<td>Summit Linux FIPS Core Crypto Module</td>
+							<td>Cryptographic Module for BIG-IP</td>
 							<td>
-								Ezurio
-									<a class="btn" role="button" data-toggle="collapse" id="a12827" href="#d12827" onclick="ShowContacts(12827)">
-										<i id="i12827" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								F5, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12827" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/2/2025)</td>
+							<td class="nowrap">Pending Review  (2/25/2026)</td>
+						</tr>
+						<tr>
+							<td>Cryptographic Module for BIG-IP</td>
+							<td>
+								F5, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13403" href="#d13403" onclick="ShowContacts(13403)">
+										<i id="i13403" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13403" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
 						</tr>
 						<tr>
 							<td>Device Cryptographic Module</td>
 							<td>
 								F5, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12605" href="#d12605" onclick="ShowContacts(12605)">
-										<i id="i12605" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13404" href="#d13404" onclick="ShowContacts(13404)">
+										<i id="i13404" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12605" class="collapse"></div>
+									<div id="d13404" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/30/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
+						</tr>
+						<tr>
+							<td>F5OS Cryptographic Module Version C-1.8.1 VELOS Chassis</td>
+							<td>
+								F5, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13017" href="#d13017" onclick="ShowContacts(13017)">
+										<i id="i13017" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13017" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/14/2026)</td>
 						</tr>
 						<tr>
 							<td>F5OS-A Cryptographic Module</td>
 							<td>
 								F5, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12974" href="#d12974" onclick="ShowContacts(12974)">
-										<i id="i12974" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13401" href="#d13401" onclick="ShowContacts(13401)">
+										<i id="i13401" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12974" class="collapse"></div>
+									<div id="d13401" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/9/2025)</td>
+							<td class="nowrap">Review  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>FEITIAN ePass Token Cryptographic Module</td>
+							<td>MonoCrypt AES Enhanced Crypto Library</td>
 							<td>
-								FEITIAN Technologies Co., Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12909" href="#d12909" onclick="ShowContacts(12909)">
-										<i id="i12909" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Focus Systems Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13717" href="#d13717" onclick="ShowContacts(13717)">
+										<i id="i13717" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12909" class="collapse"></div>
+									<div id="d13717" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/20/2024)</td>
+							<td class="nowrap">Pending Review  (3/17/2026)</td>
 						</tr>
 						<tr>
-							<td>Forcepoint Next Generation Firewall for Desktop Appliances</td>
+							<td>Fortanix DSM Appliance</td>
 							<td>
-								Forcepoint
-									<a class="btn" role="button" data-toggle="collapse" id="a13391" href="#d13391" onclick="ShowContacts(13391)">
-										<i id="i13391" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Fortanix, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13635" href="#d13635" onclick="ShowContacts(13635)">
+										<i id="i13635" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13391" class="collapse"></div>
+									<div id="d13635" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/16/2025)</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
+						</tr>
+						<tr>
+							<td>FortiClient Crypto Module v1.0</td>
+							<td>
+								Fortinet Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13558" href="#d13558" onclick="ShowContacts(13558)">
+										<i id="i13558" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13558" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/28/2026)</td>
 						</tr>
 						<tr>
 							<td>FortiSwitch Crypto Library</td>
@@ -1321,7 +1646,7 @@
 									<div id="d13074" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/12/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/20/2026)</td>
 						</tr>
 						<tr>
 							<td>FortiAP 7.4</td>
@@ -1333,19 +1658,31 @@
 									<div id="d12839" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/13/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/6/2026)</td>
 						</tr>
 						<tr>
-							<td>FortiAP Access Points with FortiAP 7.4</td>
+							<td>FortiGate 7.2 and 7.4</td>
 							<td>
 								Fortinet, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12840" href="#d12840" onclick="ShowContacts(12840)">
-										<i id="i12840" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a12915" href="#d12915" onclick="ShowContacts(12915)">
+										<i id="i12915" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12840" class="collapse"></div>
+									<div id="d12915" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/29/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/14/2026)</td>
+						</tr>
+						<tr>
+							<td>FortiGate-VM 7.2/7.4</td>
+							<td>
+								Fortinet, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a12914" href="#d12914" onclick="ShowContacts(12914)">
+										<i id="i12914" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12914" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/14/2026)</td>
 						</tr>
 						<tr>
 							<td>FortiOS 7.2/7.4</td>
@@ -1357,223 +1694,475 @@
 									<div id="d12913" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/16/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/14/2026)</td>
 						</tr>
 						<tr>
-							<td>Postal xRevenector US 2023</td>
+							<td>FUJIFILM BI Cryptographic Kernel Module for WRL</td>
 							<td>
-								FP InovoLabs GmbH
-									<a class="btn" role="button" data-toggle="collapse" id="a12832" href="#d12832" onclick="ShowContacts(12832)">
-										<i id="i12832" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								FUJIFILM Business Innovation Corp.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12832" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/8/2024)</td>
+							<td class="nowrap">Pending Review  (5/13/2026)</td>
+						</tr>
+						<tr>
+							<td>GD SecureComm Crypto</td>
+							<td>
+								General Dynamics Mission Systems
+									<a class="btn" role="button" data-toggle="collapse" id="a13618" href="#d13618" onclick="ShowContacts(13618)">
+										<i id="i13618" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13618" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/22/2026)</td>
 						</tr>
 						<tr>
 							<td>Go Cryptographic Module</td>
 							<td>
 								Geomys LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a13173" href="#d13173" onclick="ShowContacts(13173)">
-										<i id="i13173" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13601" href="#d13601" onclick="ShowContacts(13601)">
+										<i id="i13601" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13173" class="collapse"></div>
+									<div id="d13601" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/8/2025)</td>
+							<td class="nowrap">Pending Review  (4/25/2026)</td>
 						</tr>
 						<tr>
-							<td> Sm@rtCafé Expert 8.1</td>
+							<td>Geotab Extended Cryptographic Module</td>
 							<td>
-								Giesecke+Devrient ePayments GmbH
-									<a class="btn" role="button" data-toggle="collapse" id="a13014" href="#d13014" onclick="ShowContacts(13014)">
-										<i id="i13014" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Geotab Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13567" href="#d13567" onclick="ShowContacts(13567)">
+										<i id="i13567" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13014" class="collapse"></div>
+									<div id="d13567" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/26/2024)</td>
+							<td class="nowrap">Pending Resubmission  (5/19/2026)</td>
+						</tr>
+						<tr>
+							<td>Look-aside Cryptography and Compression Engine (LCE)</td>
+							<td>
+								Google LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13706" href="#d13706" onclick="ShowContacts(13706)">
+										<i id="i13706" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13706" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/28/2026)</td>
+						</tr>
+						<tr>
+							<td>B227 True Random Number Generator (TRNG) Cryptographic Module</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13663" href="#d13663" onclick="ShowContacts(13663)">
+										<i id="i13663" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13663" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/12/2026)</td>
+						</tr>
+						<tr>
+							<td>B227 True Random Number Generator (TRNG) Cryptographic Module</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13501" href="#d13501" onclick="ShowContacts(13501)">
+										<i id="i13501" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13501" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/12/2026)</td>
 						</tr>
 						<tr>
 							<td>BoringCrypto</td>
 							<td>
 								Google, LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a13004" href="#d13004" onclick="ShowContacts(13004)">
-										<i id="i13004" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13566" href="#d13566" onclick="ShowContacts(13566)">
+										<i id="i13566" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13004" class="collapse"></div>
+									<div id="d13566" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/15/2024)</td>
+							<td class="nowrap">Review  (4/27/2026)</td>
 						</tr>
 						<tr>
 							<td>BoringCrypto</td>
 							<td>
 								Google, LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a13186" href="#d13186" onclick="ShowContacts(13186)">
-										<i id="i13186" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13650" href="#d13650" onclick="ShowContacts(13650)">
+										<i id="i13650" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13186" class="collapse"></div>
+									<div id="d13650" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/13/2024)</td>
+							<td class="nowrap">Review  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>OpenSK Cryptographic Module</td>
+							<td>BoringCrypto</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/7/2026)</td>
+						</tr>
+						<tr>
+							<td>BoringCrypto</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13434" href="#d13434" onclick="ShowContacts(13434)">
+										<i id="i13434" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13434" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
+						</tr>
+						<tr>
+							<td>Inline Crypto Engine (ICE)</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13497" href="#d13497" onclick="ShowContacts(13497)">
+										<i id="i13497" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13497" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/14/2026)</td>
+						</tr>
+						<tr>
+							<td>Inline Crypto Engine (ICE)</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13599" href="#d13599" onclick="ShowContacts(13599)">
+										<i id="i13599" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13599" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/14/2026)</td>
+						</tr>
+						<tr>
+							<td>Integrated Compute Complex (ICC)</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13500" href="#d13500" onclick="ShowContacts(13500)">
+										<i id="i13500" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13500" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Integrated Compute Complex (ICC)</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13662" href="#d13662" onclick="ShowContacts(13662)">
+										<i id="i13662" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13662" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Look-aside Cryptography and Compression Engine (LCE)</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13498" href="#d13498" onclick="ShowContacts(13498)">
+										<i id="i13498" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13498" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Non-Volatile Memory express (NVMe) Data Path Security Cluster (DPSC) Module</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13600" href="#d13600" onclick="ShowContacts(13600)">
+										<i id="i13600" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13600" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/15/2026)</td>
+						</tr>
+						<tr>
+							<td>Non-Volatile Memory express (NVMe) Data Path Security Cluster (DPSC) Module</td>
+							<td>
+								Google, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13499" href="#d13499" onclick="ShowContacts(13499)">
+										<i id="i13499" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13499" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/15/2026)</td>
+						</tr>
+						<tr>
+							<td>Knuckle Cryptographic Module</td>
 							<td>
 								Google, LLC.
-									<a class="btn" role="button" data-toggle="collapse" id="a12579" href="#d12579" onclick="ShowContacts(12579)">
-										<i id="i12579" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13701" href="#d13701" onclick="ShowContacts(13701)">
+										<i id="i13701" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12579" class="collapse"></div>
+									<div id="d13701" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/2/2024)</td>
+							<td class="nowrap">Pending Review  (2/10/2026)</td>
 						</tr>
 						<tr>
-							<td>River Redux Cryptographic Module</td>
+							<td>Hikvision FIPS Provider</td>
 							<td>
-								Google, LLC.
-									<a class="btn" role="button" data-toggle="collapse" id="a13037" href="#d13037" onclick="ShowContacts(13037)">
-										<i id="i13037" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Hangzhou Hikvision Digital Technology Co., Ltd
+									<a class="btn" role="button" data-toggle="collapse" id="a13380" href="#d13380" onclick="ShowContacts(13380)">
+										<i id="i13380" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13037" class="collapse"></div>
+									<div id="d13380" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/24/2024)</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>Titan-BPN Cryptographic Module</td>
+							<td>HPE Aruba Networking VIA Cryptographic Module</td>
 							<td>
-								Google, LLC.
-									<a class="btn" role="button" data-toggle="collapse" id="a13036" href="#d13036" onclick="ShowContacts(13036)">
-										<i id="i13036" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Hewlett Packard Enterprise
+									<a class="btn" role="button" data-toggle="collapse" id="a13263" href="#d13263" onclick="ShowContacts(13263)">
+										<i id="i13263" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13036" class="collapse"></div>
+									<div id="d13263" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/31/2024)</td>
+							<td class="nowrap">Pending Resubmission  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>HID Global ActivID Applet 2.7.7 & 2.7.8 on Thales IDCore 3230 Platform </td>
+							<td>HPE Cryptographic Module</td>
+							<td>
+								Hewlett Packard Enterprise 
+									<a class="btn" role="button" data-toggle="collapse" id="a13467" href="#d13467" onclick="ShowContacts(13467)">
+										<i id="i13467" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13467" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/21/2026)</td>
+						</tr>
+						<tr>
+							<td>iLO 5 & iLO 6 Cryptographic Module </td>
+							<td>
+								Hewlett Packard Enterprise Development LP
+									<a class="btn" role="button" data-toggle="collapse" id="a13603" href="#d13603" onclick="ShowContacts(13603)">
+										<i id="i13603" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13603" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/11/2026)</td>
+						</tr>
+						<tr>
+							<td>HID Applets v4.0 on NXP JCOP 4.5 P71D600</td>
 							<td>
 								HID Global
-									<a class="btn" role="button" data-toggle="collapse" id="a12828" href="#d12828" onclick="ShowContacts(12828)">
-										<i id="i12828" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a12930" href="#d12930" onclick="ShowContacts(12930)">
+										<i id="i12930" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12828" class="collapse"></div>
+									<div id="d12930" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Finalization  (6/11/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
 						</tr>
 						<tr>
-							<td>Hitachi Embedded Storage Manager Kernel Crypto API Cryptographic Module</td>
+							<td>Hitachi Storage Hardware Encryption Module</td>
 							<td>
 								Hitachi Vantara, Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12992" href="#d12992" onclick="ShowContacts(12992)">
-										<i id="i12992" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13632" href="#d13632" onclick="ShowContacts(13632)">
+										<i id="i13632" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12992" class="collapse"></div>
+									<div id="d13632" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/15/2024)</td>
+							<td class="nowrap">Review  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>IBM(R) NVMe FlashCore(TM) Module 2</td>
+							<td>HPE Juniper Networking EX4400 Ethernet Switch</td>
 							<td>
-								IBM(R) Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a11799" href="#d11799" onclick="ShowContacts(11799)">
-										<i id="i11799" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								HPE Juniper Networking 
+									<a class="btn" role="button" data-toggle="collapse" id="a13774" href="#d13774" onclick="ShowContacts(13774)">
+										<i id="i13774" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d11799" class="collapse"></div>
+									<div id="d13774" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">On Hold  (5/22/2023)</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>IBM(R) NVMe FlashCore(TM) Module 3</td>
+							<td>HPE Juniper Networking Junos 24.4R1 MX240/480/960 series and EX9204/9208/9214 Series Routing and Switching platforms with MACsec capability</td>
 							<td>
-								IBM(R) Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a11987" href="#d11987" onclick="ShowContacts(11987)">
-										<i id="i11987" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								HPE Juniper Networking
+									<a class="btn" role="button" data-toggle="collapse" id="a13410" href="#d13410" onclick="ShowContacts(13410)">
+										<i id="i13410" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d11987" class="collapse"></div>
+									<div id="d13410" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">On Hold  (5/8/2024)</td>
+							<td class="nowrap">Pending Review  (2/18/2026)</td>
 						</tr>
 						<tr>
-							<td>Infinera G42</td>
+							<td>HPE Juniper Networking QFX5120-48YM</td>
+							<td>
+								HPE Juniper Networking
+									<a class="btn" role="button" data-toggle="collapse" id="a13232" href="#d13232" onclick="ShowContacts(13232)">
+										<i id="i13232" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13232" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/9/2026)</td>
+						</tr>
+						<tr>
+							<td>Junos® OS Evolved Juniper Express 5 MACsec Cryptographic Module Version 1.0</td>
+							<td>
+								HPE Juniper Networking
+									<a class="btn" role="button" data-toggle="collapse" id="a13240" href="#d13240" onclick="ShowContacts(13240)">
+										<i id="i13240" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13240" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
+						</tr>
+						<tr>
+							<td>IBM® Crypto for C</td>
+							<td>
+								IBM Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/15/2026)</td>
+						</tr>
+						<tr>
+							<td>UT-125 FIPS #41,#51 and #61</td>
+							<td>
+								Icom Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13622" href="#d13622" onclick="ShowContacts(13622)">
+										<i id="i13622" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13622" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>FIPS Applet on RookySE</td>
+							<td>
+								IDEMIA
+									<a class="btn" role="button" data-toggle="collapse" id="a13726" href="#d13726" onclick="ShowContacts(13726)">
+										<i id="i13726" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13726" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/25/2026)</td>
+						</tr>
+						<tr>
+							<td>Infinera Groove G30 Cryptographic Module</td>
 							<td>
 								Infinera Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12797" href="#d12797" onclick="ShowContacts(12797)">
-										<i id="i12797" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13731" href="#d13731" onclick="ShowContacts(13731)">
+										<i id="i13731" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12797" class="collapse"></div>
+									<div id="d13731" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/26/2024)</td>
+							<td class="nowrap">Pending Review  (4/14/2026)</td>
 						</tr>
 						<tr>
-							<td>Infinera G42</td>
-							<td>
-								Infinera Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12723" href="#d12723" onclick="ShowContacts(12723)">
-										<i id="i12723" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12723" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/29/2024)</td>
-						</tr>
-						<tr>
-							<td>Infinidat Cryptographic Module</td>
-							<td>
-								Infinidat, Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12801" href="#d12801" onclick="ShowContacts(12801)">
-										<i id="i12801" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12801" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/18/2024)</td>
-						</tr>
-						<tr>
-							<td>Intel FNIC Control Plane Cryptographic Module</td>
+							<td>Crypto Module for Intel® Alder Point PCH Converged Security and Manageability Engine (CSME)</td>
 							<td>
 								Intel Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a13182" href="#d13182" onclick="ShowContacts(13182)">
-										<i id="i13182" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13182" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/5/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/15/2026)</td>
 						</tr>
 						<tr>
-							<td>Intel® QuickAssist Technology (QAT) Provider</td>
+							<td>Crypto Module for Intel® Core Ultra Series 1 (Meteor Lake) Converged Security and Manageability Engine (CSME)</td>
 							<td>
 								Intel Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a11925" href="#d11925" onclick="ShowContacts(11925)">
-										<i id="i11925" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a12931" href="#d12931" onclick="ShowContacts(12931)">
+										<i id="i12931" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d11925" class="collapse"></div>
+									<div id="d12931" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (5/12/2025)</td>
+							<td class="nowrap">Cost Recovery  (5/20/2026)</td>
 						</tr>
 						<tr>
-							<td>diskAshur PRO3</td>
+							<td>Inline Crypto Engine (ICE)</td>
 							<td>
-								iStorage Limited
-									<a class="btn" role="button" data-toggle="collapse" id="a13226" href="#d13226" onclick="ShowContacts(13226)">
-										<i id="i13226" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Intel Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13492" href="#d13492" onclick="ShowContacts(13492)">
+										<i id="i13492" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13226" class="collapse"></div>
+									<div id="d13492" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/28/2025)</td>
+							<td class="nowrap">Pending Review  (2/10/2026)</td>
+						</tr>
+						<tr>
+							<td>Inline Crypto Engine (ICE)</td>
+							<td>
+								Intel Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13702" href="#d13702" onclick="ShowContacts(13702)">
+										<i id="i13702" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13702" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/12/2026)</td>
+						</tr>
+						<tr>
+							<td>Non-Volatile Memory express (NVMe) Data Path Security Cluster (DPSC) Module</td>
+							<td>
+								Intel Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13703" href="#d13703" onclick="ShowContacts(13703)">
+										<i id="i13703" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13703" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/18/2026)</td>
+						</tr>
+						<tr>
+							<td>Non-Volatile Memory express (NVMe) Data Path Security Cluster (DPSC) Module</td>
+							<td>
+								Intel Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13503" href="#d13503" onclick="ShowContacts(13503)">
+										<i id="i13503" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13503" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/7/2026)</td>
 						</tr>
 						<tr>
 							<td>diskAshur DT3</td>
@@ -1585,127 +2174,79 @@
 									<div id="d13227" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/30/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks EX, QFX and ACX Series</td>
+							<td>diskAshur PRO3</td>
 							<td>
-								Juniper Networks
-									<a class="btn" role="button" data-toggle="collapse" id="a13062" href="#d13062" onclick="ShowContacts(13062)">
-										<i id="i13062" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								iStorage Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13226" href="#d13226" onclick="ShowContacts(13226)">
+										<i id="i13226" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13062" class="collapse"></div>
+									<div id="d13226" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/27/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/28/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks EX, QFX and ACX Series with MACsec</td>
-							<td>
-								Juniper Networks
-									<a class="btn" role="button" data-toggle="collapse" id="a13063" href="#d13063" onclick="ShowContacts(13063)">
-										<i id="i13063" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13063" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/20/2024)</td>
-						</tr>
-						<tr>
-							<td>Juniper Networks SRX Series Services Gateways</td>
+							<td>Juniper Networks SRX1600 Service Gateway</td>
 							<td>
 								Juniper Networks, Inc
-									<a class="btn" role="button" data-toggle="collapse" id="a13032" href="#d13032" onclick="ShowContacts(13032)">
-										<i id="i13032" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13426" href="#d13426" onclick="ShowContacts(13426)">
+										<i id="i13426" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13032" class="collapse"></div>
+									<div id="d13426" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/17/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/1/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks EX2300, EX2300-C and EX3400 Ethernet Switches</td>
+							<td>Juniper Networks SRX1K/4K/5K/2300/4300 Services Gateways</td>
 							<td>
-								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13094" href="#d13094" onclick="ShowContacts(13094)">
-										<i id="i13094" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Juniper Networks, Inc
+									<a class="btn" role="button" data-toggle="collapse" id="a13251" href="#d13251" onclick="ShowContacts(13251)">
+										<i id="i13251" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13094" class="collapse"></div>
+									<div id="d13251" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/29/2024)</td>
+							<td class="nowrap">Cost Recovery  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks EX4100</td>
+							<td>Juniper Networks vSRX Virtual Firewall</td>
 							<td>
-								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12570" href="#d12570" onclick="ShowContacts(12570)">
-										<i id="i12570" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Juniper Networks, Inc
+									<a class="btn" role="button" data-toggle="collapse" id="a13252" href="#d13252" onclick="ShowContacts(13252)">
+										<i id="i13252" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12570" class="collapse"></div>
+									<div id="d13252" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/17/2024)</td>
+							<td class="nowrap">Pending Review  (3/17/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks MX Series 3D Universal Edge Routers</td>
+							<td>Juniper Express 4 MACsec Cryptographic Module</td>
 							<td>
 								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13061" href="#d13061" onclick="ShowContacts(13061)">
-										<i id="i13061" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13061" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/17/2024)</td>
+							<td class="nowrap">Pending Review  (3/2/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks MX2010 and MX2020 3D Universal Edge Routers </td>
+							<td>Juniper Networks MX10004, MX10008 and MX10016 with MACsec</td>
 							<td>
 								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12853" href="#d12853" onclick="ShowContacts(12853)">
-										<i id="i12853" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13437" href="#d13437" onclick="ShowContacts(13437)">
+										<i id="i13437" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12853" class="collapse"></div>
+									<div id="d13437" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/31/2024)</td>
-						</tr>
-						<tr>
-							<td>Juniper Networks MX240, MX480 and MX960 series and EX9204, EX9208, EX9214 Ethernet Switches, Junos OS 22.3R1</td>
-							<td>
-								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13095" href="#d13095" onclick="ShowContacts(13095)">
-										<i id="i13095" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13095" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/19/2024)</td>
-						</tr>
-						<tr>
-							<td>Juniper Networks MX240, MX480 and MX960 series and EX9204, EX9208, EX9214 Ethernet Switches, Release 23.4R1.9</td>
-							<td>
-								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12851" href="#d12851" onclick="ShowContacts(12851)">
-										<i id="i12851" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12851" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/31/2024)</td>
-						</tr>
-						<tr>
-							<td>Juniper Networks MX304 and EX4100 with MACsec</td>
-							<td>
-								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12568" href="#d12568" onclick="ShowContacts(12568)">
-										<i id="i12568" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12568" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/16/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
 						</tr>
 						<tr>
 							<td>Juniper Networks NFX150 and NFX250 Network Services Platform</td>
@@ -1717,22 +2258,82 @@
 									<div id="d13409" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td class="nowrap">Pending Resubmission  (1/16/2026)</td>
 						</tr>
 						<tr>
-							<td>Juniper Networks vSRX 3.0 Virtual Firewall</td>
+							<td>Junos® OS Evolved Kernel Cryptographic Module</td>
 							<td>
 								Juniper Networks, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13096" href="#d13096" onclick="ShowContacts(13096)">
-										<i id="i13096" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13096" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/7/2024)</td>
+							<td class="nowrap">Pending Review  (2/12/2026)</td>
 						</tr>
 						<tr>
-							<td>Defender 3000 USB Flash Drive </td>
+							<td>Junos® OS Evolved Kernel Cryptographic Module</td>
+							<td>
+								Juniper Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13243" href="#d13243" onclick="ShowContacts(13243)">
+										<i id="i13243" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13243" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>Junos® OS Evolved MACsec Cryptographic Library</td>
+							<td>
+								Juniper Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/2/2026)</td>
+						</tr>
+						<tr>
+							<td>Junos® OS Evolved OpenSSL Cryptographic Module</td>
+							<td>
+								Juniper Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/12/2026)</td>
+						</tr>
+						<tr>
+							<td>Junos® OS Evolved OpenSSL Cryptographic Module</td>
+							<td>
+								Juniper Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13242" href="#d13242" onclick="ShowContacts(13242)">
+										<i id="i13242" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13242" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Secure Cryptographic Module (SCM)</td>
+							<td>
+								JVCKENWOOD Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13034" href="#d13034" onclick="ShowContacts(13034)">
+										<i id="i13034" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13034" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/14/2026)</td>
+						</tr>
+						<tr>
+							<td>Defender 3000 USB Flash Drive</td>
 							<td>
 								Kanguru Solutions
 									<a class="btn" role="button" data-toggle="collapse" id="a13006" href="#d13006" onclick="ShowContacts(13006)">
@@ -1741,19 +2342,19 @@
 									<div id="d13006" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/6/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>IronKey D500S Series USB Flash Drive</td>
+							<td>KIOXIA FIPS TC58NC1137GTC Crypto Sub-Chip Class A1</td>
 							<td>
-								Kingston Technology Company, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12760" href="#d12760" onclick="ShowContacts(12760)">
-										<i id="i12760" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								KIOXIA Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13526" href="#d13526" onclick="ShowContacts(13526)">
+										<i id="i13526" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12760" class="collapse"></div>
+									<div id="d13526" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (11/6/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/15/2026)</td>
 						</tr>
 						<tr>
 							<td>KIOXIA FIPS TC58NC1137GTC/TC58NC1138GTC Crypto Sub-Chip Class B1</td>
@@ -1765,19 +2366,43 @@
 									<div id="d13208" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/19/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>ASI-HSM AHX5 kNET Cryptographic Module</td>
+							<td>BC-FNA (Bouncy Castle FIPS .NET API)</td>
 							<td>
-								Kryptus Segurança da Informação S.A.
-									<a class="btn" role="button" data-toggle="collapse" id="a12959" href="#d12959" onclick="ShowContacts(12959)">
-										<i id="i12959" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Legion of the Bouncy Castle Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13479" href="#d13479" onclick="ShowContacts(13479)">
+										<i id="i13479" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12959" class="collapse"></div>
+									<div id="d13479" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/24/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/18/2026)</td>
+						</tr>
+						<tr>
+							<td>LS2 HSM Family module</td>
+							<td>
+								Marvell Semiconductor, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13642" href="#d13642" onclick="ShowContacts(13642)">
+										<i id="i13642" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13642" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/29/2026)</td>
+						</tr>
+						<tr>
+							<td>Marvell LS2 HSM Family</td>
+							<td>
+								Marvell Semiconductor, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13636" href="#d13636" onclick="ShowContacts(13636)">
+										<i id="i13636" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13636" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/14/2026)</td>
 						</tr>
 						<tr>
 							<td>Microchip Trust Anchor TA101</td>
@@ -1789,7 +2414,7 @@
 									<div id="d13009" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/18/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/14/2026)</td>
 						</tr>
 						<tr>
 							<td>Micron® MSA11-P5 Controller Sub Chip Security Subsystem</td>
@@ -1801,7 +2426,19 @@
 									<div id="d13219" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/27/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/19/2026)</td>
+						</tr>
+						<tr>
+							<td>Micron® MSA12-P5 Controller Sub Chip Security Subsystem</td>
+							<td>
+								Micron Technology, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13682" href="#d13682" onclick="ShowContacts(13682)">
+										<i id="i13682" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13682" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/29/2026)</td>
 						</tr>
 						<tr>
 							<td>Micron® MTC22-P4 Controller Sub Chip Security Subsystem</td>
@@ -1813,7 +2450,7 @@
 									<div id="d13126" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/4/2024)</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
 						</tr>
 						<tr>
 							<td>BitLocker Dump Filter</td>
@@ -1825,7 +2462,7 @@
 									<div id="d13139" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/10/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (2/11/2026)</td>
 						</tr>
 						<tr>
 							<td>Boot Manager</td>
@@ -1837,7 +2474,7 @@
 									<div id="d13135" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/19/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (1/28/2026)</td>
 						</tr>
 						<tr>
 							<td>Code Integrity</td>
@@ -1849,7 +2486,31 @@
 									<div id="d13137" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/23/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (2/17/2026)</td>
+						</tr>
+						<tr>
+							<td>Microsoft HSM Cryptographic Module</td>
+							<td>
+								Microsoft Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13722" href="#d13722" onclick="ShowContacts(13722)">
+										<i id="i13722" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13722" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/4/2026)</td>
+						</tr>
+						<tr>
+							<td>Microsoft SymCrypt Cryptographic Library </td>
+							<td>
+								Microsoft Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13310" href="#d13310" onclick="ShowContacts(13310)">
+										<i id="i13310" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13310" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
 						</tr>
 						<tr>
 							<td>Secure Kernel Code Integrity</td>
@@ -1861,7 +2522,7 @@
 									<div id="d13138" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/23/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/14/2026)</td>
 						</tr>
 						<tr>
 							<td>Windows OS Loader</td>
@@ -1873,19 +2534,43 @@
 									<div id="d13136" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/24/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/14/2026)</td>
 						</tr>
 						<tr>
-							<td>ASTRO CDEM Motorola Advanced Crypto Engine (MACE)</td>
+							<td>CRYP CARD</td>
 							<td>
-								Motorola Solutions, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13085" href="#d13085" onclick="ShowContacts(13085)">
-										<i id="i13085" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Mitsubishi Electric Corporation Kamakura Works
+									<a class="btn" role="button" data-toggle="collapse" id="a13699" href="#d13699" onclick="ShowContacts(13699)">
+										<i id="i13699" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13085" class="collapse"></div>
+									<div id="d13699" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/30/2024)</td>
+							<td class="nowrap">Pending Review  (2/6/2026)</td>
+						</tr>
+						<tr>
+							<td>MolecuLightDX Cryptographic Module</td>
+							<td>
+								MolecuLight Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13494" href="#d13494" onclick="ShowContacts(13494)">
+										<i id="i13494" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13494" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/10/2026)</td>
+						</tr>
+						<tr>
+							<td>Motorola P25 KVL 7000 HSM</td>
+							<td>
+								Motorola Solutions Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13763" href="#d13763" onclick="ShowContacts(13763)">
+										<i id="i13763" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13763" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/8/2026)</td>
 						</tr>
 						<tr>
 							<td>Astro Subscriber Motorola Advanced Crypto Engine (MACE) - Security Level 2</td>
@@ -1897,7 +2582,7 @@
 									<div id="d13288" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/21/2025)</td>
+							<td class="nowrap">Pending Resubmission  (3/5/2026)</td>
 						</tr>
 						<tr>
 							<td>Astro Subscriber Motorola Advanced Crypto Engine (MACE) - Security Level 3</td>
@@ -1909,10 +2594,10 @@
 									<div id="d13287" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/21/2025)</td>
+							<td class="nowrap">Pending Resubmission  (3/5/2026)</td>
 						</tr>
 						<tr>
-							<td>Motorola Solutions Advanced Crypto Engine (MACE) HSM – Security Level 2</td>
+							<td>Motorola Solutions Advanced Crypto Engine (MACE) HSM - Security Level 2</td>
 							<td>
 								Motorola Solutions, Inc.
 									<a class="btn" role="button" data-toggle="collapse" id="a13224" href="#d13224" onclick="ShowContacts(13224)">
@@ -1921,10 +2606,10 @@
 									<div id="d13224" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/4/2025)</td>
+							<td class="nowrap">Pending Resubmission  (4/9/2026)</td>
 						</tr>
 						<tr>
-							<td>Motorola Solutions Advanced Crypto Engine (MACE) HSM – Security Level 3</td>
+							<td>Motorola Solutions Advanced Crypto Engine (MACE) HSM - Security Level 3</td>
 							<td>
 								Motorola Solutions, Inc.
 									<a class="btn" role="button" data-toggle="collapse" id="a13225" href="#d13225" onclick="ShowContacts(13225)">
@@ -1933,19 +2618,31 @@
 									<div id="d13225" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/30/2025)</td>
+							<td class="nowrap">Pending Resubmission  (4/9/2026)</td>
 						</tr>
 						<tr>
-							<td>NetApp StorageGRID Kernel Crypto API</td>
+							<td>Motorola Solutions Cryptographic Software Module</td>
 							<td>
-								NetApp, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13029" href="#d13029" onclick="ShowContacts(13029)">
-										<i id="i13029" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Motorola Solutions, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13029" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/23/2025)</td>
+							<td class="nowrap">Pending Review  (4/8/2026)</td>
+						</tr>
+						<tr>
+							<td>Nokia-SONiC-MACsec</td>
+							<td>
+								Nokia
+									<a class="btn" role="button" data-toggle="collapse" id="a13481" href="#d13481" onclick="ShowContacts(13481)">
+										<i id="i13481" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13481" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
 						</tr>
 						<tr>
 							<td>Nokia SR Cryptographic Module (SRCM)</td>
@@ -1957,271 +2654,583 @@
 									<div id="d12911" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/24/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/2/2026)</td>
 						</tr>
 						<tr>
-							<td>Cryptographic Library for OpenSSL powered by NTT DATA</td>
+							<td>Ad Noctem Connect 2.3</td>
 							<td>
-								NTT DATA Group Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a13370" href="#d13370" onclick="ShowContacts(13370)">
-										<i id="i13370" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Northrop Grumman Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13005" href="#d13005" onclick="ShowContacts(13005)">
+										<i id="i13005" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13370" class="collapse"></div>
+									<div id="d13005" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/28/2025)</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
 						</tr>
 						<tr>
 							<td>Nuvoton Cryptographic Library 3.0</td>
 							<td>
 								Nuvoton Technology Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12825" href="#d12825" onclick="ShowContacts(12825)">
-										<i id="i12825" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13639" href="#d13639" onclick="ShowContacts(13639)">
+										<i id="i13639" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12825" class="collapse"></div>
+									<div id="d13639" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/27/2024)</td>
+							<td class="nowrap">Review  (5/14/2026)</td>
 						</tr>
 						<tr>
-							<td>Nuvoton NPCT7xx TPM 2.0 Cryptographic Engine</td>
+							<td>H100 Tensor Core GPU</td>
 							<td>
-								Nuvoton Technology Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a13216" href="#d13216" onclick="ShowContacts(13216)">
-										<i id="i13216" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Nvidia Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13537" href="#d13537" onclick="ShowContacts(13537)">
+										<i id="i13537" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13216" class="collapse"></div>
+									<div id="d13537" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/6/2025)</td>
+							<td class="nowrap">Pending Review  (1/29/2026)</td>
 						</tr>
 						<tr>
-							<td>Nuvoton NPCT7xx TPM 2.0 Cryptographic Engine</td>
+							<td>Acme Packet 1100, Acme Packet 3900, Acme Packet 3950 and Acme Packet 4900</td>
 							<td>
-								Nuvoton Technology Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12597" href="#d12597" onclick="ShowContacts(12597)">
-										<i id="i12597" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Oracle Communications
+									<a class="btn" role="button" data-toggle="collapse" id="a13089" href="#d13089" onclick="ShowContacts(13089)">
+										<i id="i13089" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12597" class="collapse"></div>
+									<div id="d13089" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (5/14/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>Oracle Linux 9 GnuTLS Cryptographic Module</td>
+							<td>Acme Packet 4600 and Acme Packet 6350</td>
+							<td>
+								Oracle Communications
+									<a class="btn" role="button" data-toggle="collapse" id="a13090" href="#d13090" onclick="ShowContacts(13090)">
+										<i id="i13090" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13090" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/21/2026)</td>
+						</tr>
+						<tr>
+							<td>Acme Packet VME</td>
+							<td>
+								Oracle Communications
+									<a class="btn" role="button" data-toggle="collapse" id="a13091" href="#d13091" onclick="ShowContacts(13091)">
+										<i id="i13091" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13091" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/21/2026)</td>
+						</tr>
+						<tr>
+							<td>Oracle Linux 8 Unbreakable Enterprise Kernel (UEK7) Cryptographic Module and Oracle Linux 9 Unbreakable Enterprise Kernel (UEK7) Cryptographic Module</td>
 							<td>
 								Oracle Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12495" href="#d12495" onclick="ShowContacts(12495)">
-										<i id="i12495" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12495" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/10/2025)</td>
+							<td class="nowrap">Pending Review  (5/15/2026)</td>
 						</tr>
 						<tr>
-							<td>Oracle Linux 9 Kernel Crypto API Cryptographic Module</td>
+							<td>Oracle Linux 9 NSS Cryptographic Module</td>
 							<td>
 								Oracle Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12497" href="#d12497" onclick="ShowContacts(12497)">
-										<i id="i12497" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12497" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/9/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
 						</tr>
 						<tr>
-							<td>OVHcloud KMS</td>
+							<td>Oracle Linux 9 OpenSSL FIPS Provider</td>
 							<td>
-								OVHcloud
-									<a class="btn" role="button" data-toggle="collapse" id="a13413" href="#d13413" onclick="ShowContacts(13413)">
-										<i id="i13413" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Oracle Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13413" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
-							<td>FIPS 140-2</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (4/30/2026)</td>
 						</tr>
 						<tr>
-							<td>PL-4000M and PL-4000T</td>
+							<td>Oracle OpenSSL FIPS Provider</td>
+							<td>
+								Oracle Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13544" href="#d13544" onclick="ShowContacts(13544)">
+										<i id="i13544" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13544" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>PL-2000GM and PL-2000GA</td>
 							<td>
 								PacketLight Networks Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12573" href="#d12573" onclick="ShowContacts(12573)">
-										<i id="i12573" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13352" href="#d13352" onclick="ShowContacts(13352)">
+										<i id="i13352" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12573" class="collapse"></div>
+									<div id="d13352" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/16/2024)</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
+						</tr>
+						<tr>
+							<td>GlobalProtect App</td>
+							<td>
+								Palo Alto Networks
+									<a class="btn" role="button" data-toggle="collapse" id="a13670" href="#d13670" onclick="ShowContacts(13670)">
+										<i id="i13670" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13670" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
+						</tr>
+						<tr>
+							<td>GlobalProtect App</td>
+							<td>
+								Palo Alto Networks
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/29/2026)</td>
+						</tr>
+						<tr>
+							<td>Palo Alto Networks Core Crypto Module</td>
+							<td>
+								Palo Alto Networks
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/26/2026)</td>
+						</tr>
+						<tr>
+							<td>Panorama 10.2 M-200, M-300, M-600 and M-700</td>
+							<td>
+								Palo Alto Networks Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/4/2026)</td>
+						</tr>
+						<tr>
+							<td>WildFire 10.2 WF-500 and WF-500-B</td>
+							<td>
+								Palo Alto Networks Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/23/2026)</td>
+						</tr>
+						<tr>
+							<td>WildFire 11.1/11.2 WF-500 and WF-500-B</td>
+							<td>
+								Palo Alto Networks Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13637" href="#d13637" onclick="ShowContacts(13637)">
+										<i id="i13637" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13637" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/8/2026)</td>
+						</tr>
+						<tr>
+							<td>Panorama Virtual Appliance 10.2</td>
+							<td>
+								Palo Alto Networks, Inc
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/4/2026)</td>
+						</tr>
+						<tr>
+							<td>Palo Alto Networks SD-WAN  Virtual Instant-On Network (vION)</td>
+							<td>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/13/2026)</td>
 						</tr>
 						<tr>
 							<td>Palo Alto Networks SD-WAN Instant-On Network (ION) Devices ION 1200, ION 1200-S, ION 3200, ION 3200H, ION 5200, and ION 9200</td>
 							<td>
-								Palo Alto Networks
+								Palo Alto Networks, Inc.
 									<a class="btn" role="button" data-toggle="collapse" id="a13051" href="#d13051" onclick="ShowContacts(13051)">
 										<i id="i13051" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
 									<div id="d13051" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/20/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (12/1/2025)</td>
+						</tr>
+						<tr>
+							<td>Palo Alto Networks SD-WAN Instant-On Network (ION) Devices ION 1200, ION 1200-S, ION 3200, ION 5200, and ION 9200</td>
+							<td>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/16/2026)</td>
 						</tr>
 						<tr>
 							<td>Palo Alto Networks SD-WAN ION Core Crypto Module</td>
 							<td>
-								Palo Alto Networks
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/16/2026)</td>
+						</tr>
+						<tr>
+							<td>Palo Alto Networks SD-WAN ION Core Crypto Module</td>
+							<td>
+								Palo Alto Networks, Inc.
 									<a class="btn" role="button" data-toggle="collapse" id="a13049" href="#d13049" onclick="ShowContacts(13049)">
 										<i id="i13049" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
 									<div id="d13049" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/7/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/25/2026)</td>
 						</tr>
 						<tr>
 							<td>Palo Alto Networks SD-WAN Virtual Instant-On Network (vION)</td>
 							<td>
-								Palo Alto Networks
+								Palo Alto Networks, Inc.
 									<a class="btn" role="button" data-toggle="collapse" id="a13050" href="#d13050" onclick="ShowContacts(13050)">
 										<i id="i13050" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
 									<div id="d13050" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/24/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (12/1/2025)</td>
 						</tr>
 						<tr>
-							<td>Wave Relay® Kernel Space Crypto Module</td>
+							<td>Panorama 11.1/11.2 running on M-200, M-300, M-600 and M-700 </td>
 							<td>
-								Persistent Systems, LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a12919" href="#d12919" onclick="ShowContacts(12919)">
-										<i id="i12919" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13488" href="#d13488" onclick="ShowContacts(13488)">
+										<i id="i13488" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12919" class="collapse"></div>
+									<div id="d13488" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">On Hold  (6/10/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/8/2026)</td>
 						</tr>
 						<tr>
-							<td>Wave Relay® User Space Crypto Module</td>
+							<td>PAN-OS 10.2 running on PA-220, PA-220R, PA-400 Series, PA-800 Series, PA-3200 Series, PA-3400 Series, PA-5200 Series, PA-5400 Series, PA-5450, and PA-7000 Series NGFWs</td>
 							<td>
-								Persistent Systems, LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a12975" href="#d12975" onclick="ShowContacts(12975)">
-										<i id="i12975" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12975" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/3/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>SafeCase Security Module</td>
+							<td>PAN-OS 10.2 VM-Series</td>
+							<td>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
+						</tr>
+						<tr>
+							<td>PAN-OS 11.1 and 11.2 VM-Series</td>
+							<td>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a12857" href="#d12857" onclick="ShowContacts(12857)">
+										<i id="i12857" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12857" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/8/2026)</td>
+						</tr>
+						<tr>
+							<td>PAN-OS 11.1/11.2 running on PA-400 Series, PA-800 Series, PA-1400 Series, PA-3200 Series, PA-3400 Series, PA-5200 Series, PA-5400 Series, PA-5450, PA-7000 Series, and PA-7500 NGFWs</td>
+							<td>
+								Palo Alto Networks, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a12856" href="#d12856" onclick="ShowContacts(12856)">
+										<i id="i12856" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12856" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
+						</tr>
+						<tr>
+							<td>Panorama Virtual Appliance 11.1 and 11.2</td>
+							<td>
+								Palo Alto Networks, Incs
+									<a class="btn" role="button" data-toggle="collapse" id="a13493" href="#d13493" onclick="ShowContacts(13493)">
+										<i id="i13493" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13493" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/8/2026)</td>
+						</tr>
+						<tr>
+							<td>Phison PASCARI X series/ Seagate Nytro NVMe TCG OPAL SSC Self-Encrypting Enterprise SSD </td>
+							<td>
+								Phison Electronics Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a12969" href="#d12969" onclick="ShowContacts(12969)">
+										<i id="i12969" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12969" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/25/2026)</td>
+						</tr>
+						<tr>
+							<td>X5 Postal Security Device (PSD)</td>
+							<td>
+								Pitney Bowes, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (4/24/2026)</td>
+						</tr>
+						<tr>
+							<td>PQCryptoLib-Core</td>
+							<td>
+								PQShield Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13598" href="#d13598" onclick="ShowContacts(13598)">
+										<i id="i13598" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13598" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (2/13/2026)</td>
+						</tr>
+						<tr>
+							<td>ENFORCER R2</td>
+							<td>
+								Private Machines Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a12936" href="#d12936" onclick="ShowContacts(12936)">
+										<i id="i12936" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12936" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/11/2026)</td>
+						</tr>
+						<tr>
+							<td>Privoro SafeCase Security Module</td>
 							<td>
 								Privoro LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a11995" href="#d11995" onclick="ShowContacts(11995)">
-										<i id="i11995" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13348" href="#d13348" onclick="ShowContacts(13348)">
+										<i id="i13348" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d11995" class="collapse"></div>
+									<div id="d13348" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (4/29/2024)</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>Proofpoint Cryptographic Module</td>
+							<td>Purity Encryption Module</td>
 							<td>
-								Proofpoint Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13425" href="#d13425" onclick="ShowContacts(13425)">
-										<i id="i13425" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Pure Storage, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13536" href="#d13536" onclick="ShowContacts(13536)">
+										<i id="i13536" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13425" class="collapse"></div>
+									<div id="d13536" class="collapse"></div>
 							</td>
-							<td>FIPS 140-2</td>
-							<td class="nowrap">Review Pending  (6/11/2025)</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/24/2026)</td>
 						</tr>
 						<tr>
-							<td>Qualcomm(R) Crypto Engine Core</td>
+							<td>Quadient Postal Security Device</td>
+							<td>
+								Quadient Technologies France
+									<a class="btn" role="button" data-toggle="collapse" id="a13223" href="#d13223" onclick="ShowContacts(13223)">
+										<i id="i13223" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13223" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
+						</tr>
+						<tr>
+							<td>Qualcomm® Crypto Engine Core</td>
 							<td>
 								Qualcomm Technologies, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12993" href="#d12993" onclick="ShowContacts(12993)">
-										<i id="i12993" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13766" href="#d13766" onclick="ShowContacts(13766)">
+										<i id="i13766" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12993" class="collapse"></div>
+									<div id="d13766" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/2/2024)</td>
+							<td class="nowrap">Pending Review  (5/7/2026)</td>
 						</tr>
 						<tr>
-							<td>Qualcomm(R) Inline Crypto Engine (UFS)</td>
+							<td>Qualcomm® Crypto Engine Core</td>
 							<td>
 								Qualcomm Technologies, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12944" href="#d12944" onclick="ShowContacts(12944)">
-										<i id="i12944" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13550" href="#d13550" onclick="ShowContacts(13550)">
+										<i id="i13550" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12944" class="collapse"></div>
+									<div id="d13550" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/4/2025)</td>
+							<td class="nowrap">Pending Resubmission  (4/15/2026)</td>
+						</tr>
+						<tr>
+							<td>Qualcomm® Crypto Engine Core</td>
+							<td>
+								Qualcomm Technologies, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13643" href="#d13643" onclick="ShowContacts(13643)">
+										<i id="i13643" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13643" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (3/25/2026)</td>
+						</tr>
+						<tr>
+							<td>Qualcomm® Inline Crypto Engine (UFS)</td>
+							<td>
+								Qualcomm Technologies, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Qualcomm® Inline Crypto Engine (UFS)</td>
+							<td>
+								Qualcomm Technologies, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13464" href="#d13464" onclick="ShowContacts(13464)">
+										<i id="i13464" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13464" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/8/2026)</td>
+						</tr>
+						<tr>
+							<td>Qualcomm® Inline Crypto Engine (UFS)</td>
+							<td>
+								Qualcomm Technologies, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13509" href="#d13509" onclick="ShowContacts(13509)">
+										<i id="i13509" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13509" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/14/2026)</td>
 						</tr>
 						<tr>
 							<td>Qualcomm® Pseudo Random Number Generator</td>
 							<td>
 								Qualcomm Technologies, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13414" href="#d13414" onclick="ShowContacts(13414)">
-										<i id="i13414" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13721" href="#d13721" onclick="ShowContacts(13721)">
+										<i id="i13721" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13414" class="collapse"></div>
+									<div id="d13721" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td class="nowrap">Pending Review  (3/31/2026)</td>
 						</tr>
 						<tr>
 							<td>Qualcomm® Pseudo Random Number Generator</td>
 							<td>
 								Qualcomm Technologies, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13191" href="#d13191" onclick="ShowContacts(13191)">
-										<i id="i13191" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13191" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td class="nowrap">Review  (5/22/2026)</td>
 						</tr>
 						<tr>
-							<td>Rajant In-Line Security Module (RiSM)</td>
+							<td>Qualcomm® Pseudo Random Number Generator</td>
 							<td>
-								Rajant Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a12681" href="#d12681" onclick="ShowContacts(12681)">
-										<i id="i12681" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Qualcomm Technologies, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13512" href="#d13512" onclick="ShowContacts(13512)">
+										<i id="i13512" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12681" class="collapse"></div>
+									<div id="d13512" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/16/2024)</td>
+							<td class="nowrap">Pending Resubmission  (3/25/2026)</td>
 						</tr>
 						<tr>
-							<td>VaultIP RT-130</td>
+							<td>Red Hat Enterprise Linux 9 - OpenSSL FIPS Provider</td>
 							<td>
-								Rambus Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12719" href="#d12719" onclick="ShowContacts(12719)">
-										<i id="i12719" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Red Hat(R), Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12719" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/18/2024)</td>
+							<td class="nowrap">Pending Review  (1/25/2026)</td>
 						</tr>
 						<tr>
 							<td>Red Hat Enterprise Linux 8 Kernel Cryptographic API</td>
 							<td>
 								Red Hat, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12951" href="#d12951" onclick="ShowContacts(12951)">
-										<i id="i12951" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13265" href="#d13265" onclick="ShowContacts(13265)">
+										<i id="i13265" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12951" class="collapse"></div>
+									<div id="d13265" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/12/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/30/2026)</td>
 						</tr>
 						<tr>
 							<td>Red Hat Enterprise Linux 8 NSS Cryptographic Module</td>
@@ -2233,19 +3242,31 @@
 									<div id="d12952" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/7/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (1/21/2026)</td>
 						</tr>
 						<tr>
 							<td>Red Hat Enterprise Linux 9 Kernel Cryptographic API</td>
 							<td>
 								Red Hat, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12693" href="#d12693" onclick="ShowContacts(12693)">
-										<i id="i12693" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13271" href="#d13271" onclick="ShowContacts(13271)">
+										<i id="i13271" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12693" class="collapse"></div>
+									<div id="d13271" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (6/9/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/28/2026)</td>
+						</tr>
+						<tr>
+							<td>Red Hat Enterprise Linux 9 libgcrypt</td>
+							<td>
+								Red Hat, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/9/2026)</td>
 						</tr>
 						<tr>
 							<td>RA6M4 Security Management Module</td>
@@ -2257,79 +3278,103 @@
 									<div id="d13260" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/27/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/20/2026)</td>
 						</tr>
 						<tr>
-							<td>SBC 5400 Session Border Controller  </td>
+							<td>RA8M1 Security Management Module</td>
 							<td>
-								Ribbon Communications, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12731" href="#d12731" onclick="ShowContacts(12731)">
-										<i id="i12731" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Renesas Electronics Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13605" href="#d13605" onclick="ShowContacts(13605)">
+										<i id="i13605" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12731" class="collapse"></div>
+									<div id="d13605" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/5/2024)</td>
+							<td class="nowrap">Review  (5/21/2026)</td>
 						</tr>
 						<tr>
-							<td>SBC SWe Session Border Controller</td>
-							<td>
-								Ribbon Communications, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12730" href="#d12730" onclick="ShowContacts(12730)">
-										<i id="i12730" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12730" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">In Review  (6/5/2025)</td>
-						</tr>
-						<tr>
-							<td>Ruckus FastIron ICX™ 7150/8200 Series Switch/Router</td>
+							<td>Ruckus Networks SmartZone (vSZ)</td>
 							<td>
 								Ruckus Wireless LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a12871" href="#d12871" onclick="ShowContacts(12871)">
-										<i id="i12871" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13180" href="#d13180" onclick="ShowContacts(13180)">
+										<i id="i13180" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12871" class="collapse"></div>
+									<div id="d13180" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/19/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/6/2026)</td>
 						</tr>
 						<tr>
-							<td>Ruckus FastIron ICX™ 7550/7650/7850 Series Switch/Router</td>
+							<td>Ruckus Networks Virtual SmartZone - Data Plane (vSZ-D)</td>
 							<td>
 								Ruckus Wireless LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a12872" href="#d12872" onclick="ShowContacts(12872)">
-										<i id="i12872" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13387" href="#d13387" onclick="ShowContacts(13387)">
+										<i id="i13387" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12872" class="collapse"></div>
+									<div id="d13387" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/25/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/6/2026)</td>
 						</tr>
 						<tr>
-							<td>CryptoComply 140-3 FIPS Provider</td>
+							<td>RUCKUS R770-US Access Point, R770-WW Access Point, R670-US Access Point, R670-WW Access Point, T670-US Access Point, T670-WW Access Point and T670sn-US Access Point</td>
+							<td>
+								Ruckus Wireless LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13181" href="#d13181" onclick="ShowContacts(13181)">
+										<i id="i13181" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13181" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>CryptoComply 140-3 FIPS Provider with PQC</td>
 							<td>
 								SafeLogic Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13408" href="#d13408" onclick="ShowContacts(13408)">
-										<i id="i13408" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13604" href="#d13604" onclick="ShowContacts(13604)">
+										<i id="i13604" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13408" class="collapse"></div>
+									<div id="d13604" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">In Review  (6/11/2025)</td>
+							<td class="nowrap">Cost Recovery  (5/19/2026)</td>
 						</tr>
 						<tr>
-							<td>Samsung NVMe TCG Opal SSC SEDs BM1743 Series</td>
+							<td>Samsung Kernel Cryptographic Module</td>
 							<td>
 								Samsung Electronics Co., Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a13295" href="#d13295" onclick="ShowContacts(13295)">
-										<i id="i13295" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13358" href="#d13358" onclick="ShowContacts(13358)">
+										<i id="i13358" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13295" class="collapse"></div>
+									<div id="d13358" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/28/2025)</td>
+							<td class="nowrap">Pending Review  (5/5/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung Kernel Cryptographic Module</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13555" href="#d13555" onclick="ShowContacts(13555)">
+										<i id="i13555" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13555" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung Kernel Cryptographic Module</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13357" href="#d13357" onclick="ShowContacts(13357)">
+										<i id="i13357" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13357" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/8/2026)</td>
 						</tr>
 						<tr>
 							<td>Samsung NVMe TCG Opal SSC SEDs BM1743 Series</td>
@@ -2341,7 +3386,7 @@
 									<div id="d13280" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/13/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/24/2026)</td>
 						</tr>
 						<tr>
 							<td>Samsung NVMe TCG Opal SSC SEDs BM1743 Series</td>
@@ -2353,7 +3398,19 @@
 									<div id="d13329" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/31/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/24/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung NVMe TCG Opal SSC SEDs BM1743 Series</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13295" href="#d13295" onclick="ShowContacts(13295)">
+										<i id="i13295" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13295" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/24/2026)</td>
 						</tr>
 						<tr>
 							<td>Samsung NVMe TCG Opal SSC SEDs PM1753 Series</td>
@@ -2365,43 +3422,163 @@
 									<div id="d13275" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/24/2026)</td>
 						</tr>
 						<tr>
-							<td>Samsung TCG Opal SSC Cryptographic Sub-Chip</td>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM1753 Series</td>
 							<td>
 								Samsung Electronics Co., Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a13206" href="#d13206" onclick="ShowContacts(13206)">
-										<i id="i13206" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13508" href="#d13508" onclick="ShowContacts(13508)">
+										<i id="i13508" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13206" class="collapse"></div>
+									<div id="d13508" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/14/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/13/2026)</td>
 						</tr>
 						<tr>
-							<td>Samsung TCG Opal SSC Cryptographic Sub-Chip Deneb</td>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM1753 Series</td>
 							<td>
 								Samsung Electronics Co., Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12774" href="#d12774" onclick="ShowContacts(12774)">
-										<i id="i12774" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13563" href="#d13563" onclick="ShowContacts(13563)">
+										<i id="i13563" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12774" class="collapse"></div>
+									<div id="d13563" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (12/5/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/13/2026)</td>
 						</tr>
 						<tr>
-							<td>SAP CommonCryptoLib Crypto Kernel</td>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM1753 Series</td>
 							<td>
-								SAP SE
-									<a class="btn" role="button" data-toggle="collapse" id="a12924" href="#d12924" onclick="ShowContacts(12924)">
-										<i id="i12924" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13612" href="#d13612" onclick="ShowContacts(13612)">
+										<i id="i13612" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12924" class="collapse"></div>
+									<div id="d13612" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (9/4/2024)</td>
+							<td class="nowrap">Pending Resubmission  (5/12/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM1753 Series</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13621" href="#d13621" onclick="ShowContacts(13621)">
+										<i id="i13621" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13621" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (4/30/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung NVMe TCG Opal SSC SEDs PM1753 Series</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13609" href="#d13609" onclick="ShowContacts(13609)">
+										<i id="i13609" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13609" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (4/29/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung SAS TCG Enterprise SSC SEDs PM1653a Series</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13543" href="#d13543" onclick="ShowContacts(13543)">
+										<i id="i13543" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13543" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/13/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung SAS TCG Enterprise SSC SEDs PM1653a Series</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13623" href="#d13623" onclick="ShowContacts(13623)">
+										<i id="i13623" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13623" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/1/2026)</td>
+						</tr>
+						<tr>
+							<td>Samsung SCrypto Cryptographic Module</td>
+							<td>
+								Samsung Electronics Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/1/2026)</td>
+						</tr>
+						<tr>
+							<td>Ultrastar® DC SN650 BiCS5 NVMe® TCG Opal SSD, SED</td>
+							<td>
+								SanDisk Technologies Inc
+									<a class="btn" role="button" data-toggle="collapse" id="a12847" href="#d12847" onclick="ShowContacts(12847)">
+										<i id="i12847" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12847" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/28/2026)</td>
+						</tr>
+						<tr>
+							<td>Ultrastar® DC SN655 BiCS5 NVMe® TCG Opal SSD, SED</td>
+							<td>
+								SanDisk Technologies Inc
+									<a class="btn" role="button" data-toggle="collapse" id="a13218" href="#d13218" onclick="ShowContacts(13218)">
+										<i id="i13218" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13218" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/28/2026)</td>
+						</tr>
+						<tr>
+							<td>Sansec HSM Cryptographic Module</td>
+							<td>
+								Sansec Technology Co., Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13588" href="#d13588" onclick="ShowContacts(13588)">
+										<i id="i13588" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13588" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
+						</tr>
+						<tr>
+							<td>Seagate SSG3 TCG Enterprise SSC SED FIPS 140 Module</td>
+							<td>
+								Seagate Technology LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a13720" href="#d13720" onclick="ShowContacts(13720)">
+										<i id="i13720" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13720" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/26/2026)</td>
+						</tr>
+						<tr>
+							<td>Seagate SSG5 TCG Enterprise SSC SED FIPS 140 Module</td>
+							<td>
+								Seagate Technology LLC.
+									<a class="btn" role="button" data-toggle="collapse" id="a13266" href="#d13266" onclick="ShowContacts(13266)">
+										<i id="i13266" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13266" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/12/2026)</td>
 						</tr>
 						<tr>
 							<td>VaultIC408 1.2.4</td>
@@ -2413,7 +3590,7 @@
 									<div id="d13220" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/28/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/21/2026)</td>
 						</tr>
 						<tr>
 							<td>VaultIC408 1.2.4 - Level 2</td>
@@ -2425,79 +3602,163 @@
 									<div id="d13221" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (6/3/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/13/2026)</td>
 						</tr>
 						<tr>
-							<td>SonicWALL NSa 6700</td>
+							<td>Securosys Primus HSM</td>
 							<td>
-								SonicWall, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12778" href="#d12778" onclick="ShowContacts(12778)">
-										<i id="i12778" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Securosys SA
+									<a class="btn" role="button" data-toggle="collapse" id="a13531" href="#d13531" onclick="ShowContacts(13531)">
+										<i id="i13531" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12778" class="collapse"></div>
+									<div id="d13531" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/2/2024)</td>
+							<td class="nowrap">Pending Review  (3/17/2026)</td>
 						</tr>
 						<tr>
-							<td> Vega-1 Cryptographic Module</td>
+							<td>CE Crypto Module</td>
 							<td>
-								ST Engineering Urban Solutions Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a13328" href="#d13328" onclick="ShowContacts(13328)">
-										<i id="i13328" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Senetas Corporation Ltd, distributed by Thales SA
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13328" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/30/2025)</td>
+							<td class="nowrap">Pending Review  (1/22/2026)</td>
 						</tr>
 						<tr>
-							<td>IPC Cryptographic Module</td>
+							<td>CN Series Encryptors</td>
 							<td>
-								ST Engineering Urban Solutions Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12607" href="#d12607" onclick="ShowContacts(12607)">
-										<i id="i12607" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Senetas Corporation Ltd, distributed by Thales SA (SafeNet)
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12607" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/31/2024)</td>
+							<td class="nowrap">Review  (5/26/2026)</td>
 						</tr>
 						<tr>
-							<td>Triton 2 Cryptographic Module</td>
+							<td>PE9010 and PE9030 M.2 2280D NVMe TCG Opal SSC SED</td>
 							<td>
-								ST Engineering Urban Solutions Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a12624" href="#d12624" onclick="ShowContacts(12624)">
-										<i id="i12624" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								SK hynix Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13460" href="#d13460" onclick="ShowContacts(13460)">
+										<i id="i13460" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12624" class="collapse"></div>
+									<div id="d13460" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (10/31/2024)</td>
+							<td class="nowrap">Pending Review  (8/8/2025)</td>
 						</tr>
 						<tr>
-							<td>Trusted Platform Module ST33KTPM2A / ST33KTPM2I</td>
+							<td>SK hynix PE9010 E1.S NVMe TCG Opal SSC SED</td>
 							<td>
-								STMicroelectronics
-									<a class="btn" role="button" data-toggle="collapse" id="a13025" href="#d13025" onclick="ShowContacts(13025)">
-										<i id="i13025" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								SK hynix Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13571" href="#d13571" onclick="ShowContacts(13571)">
+										<i id="i13571" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13025" class="collapse"></div>
+									<div id="d13571" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/7/2024)</td>
+							<td class="nowrap">Pending Review  (12/18/2025)</td>
 						</tr>
 						<tr>
-							<td>Trusted Platform Module ST33KTPM2X / ST33KTPM2XSPI</td>
+							<td>SK hynix PEB110 E1.S NVMe TCG Opal SSC SED</td>
 							<td>
-								STMicroelectronics
-									<a class="btn" role="button" data-toggle="collapse" id="a13164" href="#d13164" onclick="ShowContacts(13164)">
-										<i id="i13164" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								SK hynix Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13610" href="#d13610" onclick="ShowContacts(13610)">
+										<i id="i13610" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13164" class="collapse"></div>
+									<div id="d13610" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/27/2024)</td>
+							<td class="nowrap">Pending Review  (12/18/2025)</td>
+						</tr>
+						<tr>
+							<td>SK hynix PS1010 And PS1030 NVMe Opal SEDs</td>
+							<td>
+								SK hynix memory solutions America Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13562" href="#d13562" onclick="ShowContacts(13562)">
+										<i id="i13562" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13562" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (11/25/2025)</td>
+						</tr>
+						<tr>
+							<td>Solidigm® P5336 SSD (ADP-RRR VE)</td>
+							<td>
+								SK hynix NAND Product Solutions Corp (d/b/a Solidigm)
+									<a class="btn" role="button" data-toggle="collapse" id="a13680" href="#d13680" onclick="ShowContacts(13680)">
+										<i id="i13680" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13680" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/21/2026)</td>
+						</tr>
+						<tr>
+							<td>Solidigm® P5430 SSD (ADP-RRR) Essential Endurance (EE) devices (U2)</td>
+							<td>
+								Solidigm® Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13575" href="#d13575" onclick="ShowContacts(13575)">
+										<i id="i13575" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13575" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Resubmission  (5/1/2026)</td>
+						</tr>
+						<tr>
+							<td>ST Engineering & i-Engine SAM Applet on NXP P71D600</td>
+							<td>
+								ST Engineering Urban Solutions Ltd. and i-Engine Pte Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13082" href="#d13082" onclick="ShowContacts(13082)">
+										<i id="i13082" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13082" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>ST Engineering & i-Engine SSID Applet on NXP P71D600</td>
+							<td>
+								ST Engineering Urban Solutions Ltd. and i-Engine Pte Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a13083" href="#d13083" onclick="ShowContacts(13083)">
+										<i id="i13083" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13083" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/22/2026)</td>
+						</tr>
+						<tr>
+							<td>Stryker Badge Cryptographic Module</td>
+							<td>
+								Stryker Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13205" href="#d13205" onclick="ShowContacts(13205)">
+										<i id="i13205" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13205" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/11/2026)</td>
+						</tr>
+						<tr>
+							<td>Sunhillo Cryptographic Module</td>
+							<td>
+								Sunhillo Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13638" href="#d13638" onclick="ShowContacts(13638)">
+										<i id="i13638" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13638" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (5/22/2026)</td>
 						</tr>
 						<tr>
 							<td>SUSE Linux Enterprise GnuTLS Cryptographic Module</td>
@@ -2509,19 +3770,19 @@
 									<div id="d13067" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/30/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (1/20/2026)</td>
 						</tr>
 						<tr>
 							<td>SUSE Linux Enterprise Kernel Crypto API Cryptographic Module</td>
 							<td>
 								SUSE LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a13066" href="#d13066" onclick="ShowContacts(13066)">
-										<i id="i13066" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13066" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/14/2025)</td>
+							<td class="nowrap">Pending Review  (5/26/2026)</td>
 						</tr>
 						<tr>
 							<td>SUSE Linux Enterprise Libica Cryptographic Module</td>
@@ -2533,7 +3794,19 @@
 									<div id="d13069" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/2/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (3/16/2026)</td>
+						</tr>
+						<tr>
+							<td>SUSE Linux Enterprise NSS Cryptographic Module</td>
+							<td>
+								SUSE LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (12/22/2025)</td>
 						</tr>
 						<tr>
 							<td>SUSE Linux Enterprise NSS Cryptographic Module</td>
@@ -2545,31 +3818,55 @@
 									<div id="d13070" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/8/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (1/26/2026)</td>
 						</tr>
 						<tr>
-							<td>SUSE Linux Enterprise OpenSSL 1 Cryptographic Module</td>
+							<td>SUSE Linux Enterprise GnuTLS Cryptographic Module</td>
 							<td>
-								SUSE LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a13065" href="#d13065" onclick="ShowContacts(13065)">
-										<i id="i13065" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								SUSE, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13065" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/16/2025)</td>
+							<td class="nowrap">Pending Review  (12/22/2025)</td>
 						</tr>
 						<tr>
-							<td>SUSE Linux Enterprise OpenSSL 3 Cryptographic Module</td>
+							<td>SUSE Linux Enterprise Libgcrypt Cryptographic Module</td>
 							<td>
-								SUSE LLC
-									<a class="btn" role="button" data-toggle="collapse" id="a13064" href="#d13064" onclick="ShowContacts(13064)">
-										<i id="i13064" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								SUSE, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13064" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/27/2024)</td>
+							<td class="nowrap">Pending Review  (12/22/2025)</td>
+						</tr>
+						<tr>
+							<td>SUSE Linux Enterprise Libica Cryptographic Module</td>
+							<td>
+								SUSE, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (12/22/2025)</td>
+						</tr>
+						<tr>
+							<td>SUSE Linux Enterprise OpenSSL Cryptographic Module</td>
+							<td>
+								SUSE, LLC
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d-9000" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (1/30/2026)</td>
 						</tr>
 						<tr>
 							<td>iShield Key Module</td>
@@ -2581,19 +3878,67 @@
 									<div id="d12961" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/12/2025)</td>
+							<td class="nowrap">Pending Resubmission  (12/1/2025)</td>
 						</tr>
 						<tr>
-							<td>Thales Alenia Space Cryptographic Module for Microsemi RTG4 FPGA</td>
+							<td>Edge SWG</td>
 							<td>
-								Thales Alenia Space
-									<a class="btn" role="button" data-toggle="collapse" id="a13327" href="#d13327" onclick="ShowContacts(13327)">
-										<i id="i13327" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Symantec, A Division of Broadcom
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13327" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/29/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/15/2026)</td>
+						</tr>
+						<tr>
+							<td>IDPrime PIV 4.0 FIDO on IDCore3230 Platform</td>
+							<td>
+								Thales
+									<a class="btn" role="button" data-toggle="collapse" id="a13421" href="#d13421" onclick="ShowContacts(13421)">
+										<i id="i13421" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13421" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/20/2026)</td>
+						</tr>
+						<tr>
+							<td>IDPrime930C/3930C</td>
+							<td>
+								THALES
+									<a class="btn" role="button" data-toggle="collapse" id="a13743" href="#d13743" onclick="ShowContacts(13743)">
+										<i id="i13743" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13743" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/8/2026)</td>
+						</tr>
+						<tr>
+							<td>IDPrime930C/3930C FIDO2.1</td>
+							<td>
+								THALES
+									<a class="btn" role="button" data-toggle="collapse" id="a13742" href="#d13742" onclick="ShowContacts(13742)">
+										<i id="i13742" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13742" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (5/8/2026)</td>
+						</tr>
+						<tr>
+							<td>THCL FIPS Provider for OpenSSL</td>
+							<td>
+								Thales DIS (Singapore) Pte. Ltd.
+									<a class="btn" role="button" data-toggle="collapse" id="a12926" href="#d12926" onclick="ShowContacts(12926)">
+										<i id="i12926" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d12926" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/30/2026)</td>
 						</tr>
 						<tr>
 							<td>Luna M7 Cryptographic Module</td>
@@ -2605,10 +3950,10 @@
 									<div id="d13172" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (2/28/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
 						</tr>
 						<tr>
-							<td>Luna T7 Cryptographic Module</td>
+							<td>Luna T7</td>
 							<td>
 								Thales Trusted Cyber Technologies
 									<a class="btn" role="button" data-toggle="collapse" id="a13015" href="#d13015" onclick="ShowContacts(13015)">
@@ -2617,7 +3962,19 @@
 									<div id="d13015" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (5/23/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/21/2026)</td>
+						</tr>
+						<tr>
+							<td>OpenSSL FIPS Provider</td>
+							<td>
+								The OpenSSL Corporation
+									<a class="btn" role="button" data-toggle="collapse" id="a13323" href="#d13323" onclick="ShowContacts(13323)">
+										<i id="i13323" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13323" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Review  (4/28/2026)</td>
 						</tr>
 						<tr>
 							<td>TW-860-F TSM Spirit</td>
@@ -2629,7 +3986,7 @@
 									<div id="d12966" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/31/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (2/23/2026)</td>
 						</tr>
 						<tr>
 							<td>TW-900-F/950-F TSM Shadow, TW-880-F TSM Ghost Embedded, TW-870-F/875-F TSM Ghost, TW-135-F TSM Shadow High-Power</td>
@@ -2641,7 +3998,19 @@
 									<div id="d12967" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/31/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (2/23/2026)</td>
+						</tr>
+						<tr>
+							<td>Trellix Core Cryptographic AES Module</td>
+							<td>
+								Trellix
+									<a class="btn" role="button" data-toggle="collapse" id="a13469" href="#d13469" onclick="ShowContacts(13469)">
+										<i id="i13469" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									</a>
+									<div id="d13469" class="collapse"></div>
+							</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/26/2026)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS3100, NS3200, NS5100 and NS5200</td>
@@ -2653,7 +4022,7 @@
 									<div id="d13158" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/25/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/16/2025)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS3600 </td>
@@ -2665,7 +4034,7 @@
 									<div id="d13155" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/22/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/16/2025)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS7150, NS7250 and NS7350</td>
@@ -2677,7 +4046,7 @@
 									<div id="d13157" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/25/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/16/2025)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS7500 </td>
@@ -2689,7 +4058,7 @@
 									<div id="d13153" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/22/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (5/14/2026)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS7600 </td>
@@ -2701,7 +4070,7 @@
 									<div id="d13156" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/22/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/16/2025)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS9500 </td>
@@ -2713,7 +4082,7 @@
 									<div id="d13154" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/22/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/16/2025)</td>
 						</tr>
 						<tr>
 							<td>Trellix Intrusion Prevention System Sensor NS9600 </td>
@@ -2725,43 +4094,31 @@
 									<div id="d13209" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/20/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (10/16/2025)</td>
 						</tr>
 						<tr>
-							<td>Trend Micro Crypto Core OpenSSL</td>
+							<td>DB Series SSD Drives</td>
 							<td>
-								Trend Micro Incorporated
-									<a class="btn" role="button" data-toggle="collapse" id="a12587" href="#d12587" onclick="ShowContacts(12587)">
-										<i id="i12587" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								UD info Corp.
+									<a class="btn" role="button" data-toggle="collapse" id="a13363" href="#d13363" onclick="ShowContacts(13363)">
+										<i id="i13363" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d12587" class="collapse"></div>
+									<div id="d13363" class="collapse"></div>
 							</td>
-							<td>FIPS 140-2</td>
-							<td class="nowrap">Coordination  (9/18/2024)</td>
+							<td>FIPS 140-3</td>
+							<td class="nowrap">Pending Review  (3/26/2026)</td>
 						</tr>
 						<tr>
-							<td>u.trust Anchor</td>
+							<td>u.trust Anchor CSe</td>
 							<td>
 								Utimaco IS GmbH
-									<a class="btn" role="button" data-toggle="collapse" id="a13228" href="#d13228" onclick="ShowContacts(13228)">
-										<i id="i13228" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a13620" href="#d13620" onclick="ShowContacts(13620)">
+										<i id="i13620" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13228" class="collapse"></div>
+									<div id="d13620" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/9/2025)</td>
-						</tr>
-						<tr>
-							<td>WatchGuard Firebox M4800 and M5800</td>
-							<td>
-								WatchGuard Technologies, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12544" href="#d12544" onclick="ShowContacts(12544)">
-										<i id="i12544" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12544" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/24/2024)</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
 						</tr>
 						<tr>
 							<td>WatchGuard Firebox T20, T20-W, T40, T40-W, T80, NV5, T25, T25-W, T45, T45-PoE, T45-W-PoE, T45-CW, T85-PoE, M290, M390, M590 and M690</td>
@@ -2773,31 +4130,7 @@
 									<div id="d12543" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (7/23/2024)</td>
-						</tr>
-						<tr>
-							<td>Intrepid Cryptographic Firmware Module</td>
-							<td>
-								Western Digital Technologies, Inc
-									<a class="btn" role="button" data-toggle="collapse" id="a13229" href="#d13229" onclick="ShowContacts(13229)">
-										<i id="i13229" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13229" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/30/2025)</td>
-						</tr>
-						<tr>
-							<td>Ultrastar® DC SN650 BiCS5 NVMe® TCG Opal SSD, SED</td>
-							<td>
-								Western Digital Technologies, Inc
-									<a class="btn" role="button" data-toggle="collapse" id="a12847" href="#d12847" onclick="ShowContacts(12847)">
-										<i id="i12847" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12847" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (8/30/2024)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/22/2026)</td>
 						</tr>
 						<tr>
 							<td>Ultrastar DC HC555 TCG Enterprise HDD SED</td>
@@ -2809,91 +4142,55 @@
 									<div id="d13330" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (3/31/2025)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/28/2026)</td>
 						</tr>
 						<tr>
-							<td>Ultrastar® DC SN655 BiCS5 NVMe® TCG Opal SSD, SED</td>
+							<td>Ultrastar DC HC560 TCG Enterprise HDD, SED and Ultrastar DC HC570 TCG Enterprise HDD, SED</td>
 							<td>
 								Western Digital Technologies, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a13218" href="#d13218" onclick="ShowContacts(13218)">
-										<i id="i13218" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a-9000" href="#d-9000" onclick="ShowContacts(-9000)">
+										<i id="i-9000" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13218" class="collapse"></div>
+									<div id="d-9000" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/31/2025)</td>
+							<td class="nowrap">Pending Review  (12/19/2025)</td>
 						</tr>
 						<tr>
-							<td>TrustMe © W77Q64/W77Q128</td>
+							<td>Wind River OpenSSL Cryptographic Module</td>
 							<td>
-								Winbond Electronics Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a11908" href="#d11908" onclick="ShowContacts(11908)">
-										<i id="i11908" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Wind River
+									<a class="btn" role="button" data-toggle="collapse" id="a13660" href="#d13660" onclick="ShowContacts(13660)">
+										<i id="i13660" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d11908" class="collapse"></div>
+									<div id="d13660" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (4/29/2024)</td>
+							<td class="nowrap">Pending Review  (1/13/2026)</td>
 						</tr>
 						<tr>
-							<td>WinMagic Cryptographic Module for macOS/Linux</td>
+							<td>Wind River FIPS Object Module</td>
 							<td>
-								WinMagic Corp
-									<a class="btn" role="button" data-toggle="collapse" id="a13055" href="#d13055" onclick="ShowContacts(13055)">
-										<i id="i13055" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+								Wind River Systems, Inc.
+									<a class="btn" role="button" data-toggle="collapse" id="a13429" href="#d13429" onclick="ShowContacts(13429)">
+										<i id="i13429" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d13055" class="collapse"></div>
+									<div id="d13429" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/25/2025)</td>
-						</tr>
-						<tr>
-							<td>WinMagic Cryptographic Module for Windows</td>
-							<td>
-								WinMagic Corp
-									<a class="btn" role="button" data-toggle="collapse" id="a13056" href="#d13056" onclick="ShowContacts(13056)">
-										<i id="i13056" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13056" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/24/2025)</td>
-						</tr>
-						<tr>
-							<td>VaultIC408 1.2.4</td>
-							<td>
-								WISeKey SEALSQ
-									<a class="btn" role="button" data-toggle="collapse" id="a13366" href="#d13366" onclick="ShowContacts(13366)">
-										<i id="i13366" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13366" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/24/2025)</td>
+							<td class="nowrap">Pending Resubmission  (3/4/2026)</td>
 						</tr>
 						<tr>
 							<td>wolfCrypt</td>
 							<td>
 								wolfSSL Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a11093" href="#d11093" onclick="ShowContacts(11093)">
-										<i id="i11093" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
+									<a class="btn" role="button" data-toggle="collapse" id="a12904" href="#d12904" onclick="ShowContacts(12904)">
+										<i id="i12904" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
 									</a>
-									<div id="d11093" class="collapse"></div>
+									<div id="d12904" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Coordination  (10/24/2024)</td>
-						</tr>
-						<tr>
-							<td>xFusion Cryptographic Library</td>
-							<td>
-								xFusion Digital Technologies Co., Ltd.
-									<a class="btn" role="button" data-toggle="collapse" id="a13188" href="#d13188" onclick="ShowContacts(13188)">
-										<i id="i13188" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13188" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (4/4/2025)</td>
+							<td class="nowrap">Pending Resubmission  (4/16/2026)</td>
 						</tr>
 						<tr>
 							<td>YubiHSM 2 Cryptographic Module</td>
@@ -2905,31 +4202,7 @@
 									<div id="d13217" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (12/27/2024)</td>
-						</tr>
-						<tr>
-							<td>YubiKey 5 Cryptographic Module</td>
-							<td>
-								Yubico, Inc.
-									<a class="btn" role="button" data-toggle="collapse" id="a12994" href="#d12994" onclick="ShowContacts(12994)">
-										<i id="i12994" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d12994" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/19/2024)</td>
-						</tr>
-						<tr>
-							<td>Zebra 9098 Cryptographic Module</td>
-							<td>
-								Zebra Technologies Corporation
-									<a class="btn" role="button" data-toggle="collapse" id="a13185" href="#d13185" onclick="ShowContacts(13185)">
-										<i id="i13185" class="fa fa-search-plus"><span class="element-invisible">View Contacts</span></i>
-									</a>
-									<div id="d13185" class="collapse"></div>
-							</td>
-							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (1/27/2025)</td>
+							<td class="nowrap">Comment Resolution - CMVP  (5/20/2026)</td>
 						</tr>
 						<tr>
 							<td>Zimperium zKeyBox white-box cryptography library</td>
@@ -2941,21 +4214,21 @@
 									<div id="d13170" class="collapse"></div>
 							</td>
 							<td>FIPS 140-3</td>
-							<td class="nowrap">Review Pending  (11/29/2024)</td>
+							<td class="nowrap">Comment Resolution - Lab  (4/7/2026)</td>
 						</tr>
 				</tbody>
 				<tfoot id="MIPFooter">
 						<tr>
 							<td colspan="3">Displayed</td>
-							<td>207</td>
+							<td>313</td>
 						</tr>
 						<tr>
 							<td colspan="3">Not Displayed</td>
-							<td>2</td>
+							<td>12</td>
 						</tr>
 						<tr>
 							<td colspan="3">Total</td>
-							<td>209</td>
+							<td>325</td>
 						</tr>
 				</tfoot>
 			</table>
@@ -2967,7 +4240,7 @@
 <div class="row">
     <div class="col-md-12 historical-data-area" id="historical-data-area">
 
-            <span>Created <span id="page-created-date">October 11, 2016</span>, Updated <span id="page-updated-date">June 02, 2025</span></span>
+            <span>Created <span id="page-created-date">October 11, 2016</span>, Updated <span id="page-updated-date">May 12, 2026</span></span>
     </div>
 </div>
 
@@ -3008,7 +4281,7 @@
         <div class="row">
             <div class="col-sm-6">
                 <span class="hidden-xs">
-                    <a href="https://www.nist.gov" title="National Institute of Standards and Technology" rel="home" target="_blank" class="footer-nist-logo" id="footer-nist-logo-link">
+                    <a href="https://www.nist.gov" title="National Institute of Standards and Technology" rel="home" target='_blank' rel="noopener noreferrer" class="footer-nist-logo" id="footer-nist-logo-link">
                         <img src="/CSRC/Media/images/nist-logo-brand-white.svg" alt="National Institute of Standards and Technology logo" id="footer-nist-logo" />
                     </a>
                 </span>
@@ -3073,7 +4346,7 @@
         </div>
         <div class="row hidden-sm hidden-md hidden-lg">
             <div class="col-sm-12">
-                <a href="https://www.nist.gov" title="National Institute of Standards and Technology" rel="home" target="_blank" class="footer-nist-logo" id="footer-bottom-nist-logo-link">
+                <a href="https://www.nist.gov" title="National Institute of Standards and Technology" rel="home" target='_blank' rel="noopener noreferrer" class="footer-nist-logo" id="footer-bottom-nist-logo-link">
                     <img src="/CSRC/Media/images/logo_rev.png" alt="National Institute of Standards and Technology logo" id="footer-bottom-nist-logo" />
                 </a>
             </div>
@@ -3088,7 +4361,7 @@
             </div>
             <div class="col-sm-6">
                 <span class="pull-right text-right">
-                    Send inquiries to <a href="/cdn-cgi/l/email-protection#086b7b7a6b256166797d617a714866617b7c266f677e377b7d6a626d6b7c354b5b5a4b284166797d617a71" style="display: inline-block;" id="footer-inquiries-link"><span class="__cf_email__" data-cfemail="8ae9f9f8e9a7e3e4fbffe3f8f3cae4e3f9fea4ede5fc">[email&#160;protected]</span></a>
+                    Send inquiries to <a href="/cdn-cgi/l/email-protection#9af9e9e8f9b7f3f4ebeff3e8e3daf4f3e9eeb4fdf5eca5e9eff8f0fff9eea7d9c9c8d9bad3f4ebeff3e8e3" style="display: inline-block;" id="footer-inquiries-link"><span class="__cf_email__" data-cfemail="2e4d5d5c4d0347405f5b475c576e40475d5a00494158">[email&#160;protected]</span></a>
                 </span>
             </div>
         </div>
@@ -3123,5 +4396,5 @@
 
     
 
-    </body>
+    <script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a02603e02cfacbaa',t:'MTc3OTg5NTM0Nw=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
 </html>


### PR DESCRIPTION
The previous Geomys LLC "Go Cryptographic Module" submission (Pending Review 5/8/2025) has exited the queue. A new submission entered Pending Review on 4/25/2026. This PR updates the cutoff date accordingly and refreshes `testdata/modules-in-process-list`.

While refreshing, I noticed that NIST renamed the status label from `Review Pending` to `Pending Review`. The filter string, regex, function names, and tests have been updated to match the new label.

With current data, the program now reports:

```
Total Pending Review entries: 105
Entries before 4/25/2026: 77
```

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go run main.go testdata/modules-in-process-list` prints the expected counts