### PR TITLE
mtc-log-list: add browser entry generator

### DIFF
--- a/mtc-log-list/README.md
+++ b/mtc-log-list/README.md
@@ -1,0 +1,16 @@
+# MTC log-list entry generator
+
+A client-side tool for generating entries in the
+[witness-network log-list format](https://witness-network.org/log-list-format)
+for issuance logs following [c2sp.org/mtc-tlog](https://c2sp.org/mtc-tlog).
+
+The key input is an ML-DSA-44 public key, either in its raw encoding or encoded
+as a PKIX SubjectPublicKeyInfo in PEM (`PUBLIC KEY`) or DER form. The verifier key
+is generated in Go WebAssembly with [Torchwood](https://filippo.io/torchwood).
+
+To rebuild:
+
+```console
+GOOS=js GOARCH=wasm go build -o main.wasm .
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" .
+```

--- a/mtc-log-list/README.md
+++ b/mtc-log-list/README.md
@@ -5,7 +5,8 @@ A client-side tool for generating entries in the
 for issuance logs following [c2sp.org/mtc-tlog](https://c2sp.org/mtc-tlog).
 
 The key input is an ML-DSA-44 public key, either in its raw encoding or encoded
-as a PKIX SubjectPublicKeyInfo in PEM (`PUBLIC KEY`) or DER form. The verifier key
+as a PKIX SubjectPublicKeyInfo in PEM (`PUBLIC KEY`) or DER form. It can be
+uploaded as a file, or pasted as PEM or base64-encoded raw/DER bytes. The verifier key
 is generated in Go WebAssembly with [Torchwood](https://filippo.io/torchwood).
 
 To rebuild:

--- a/mtc-log-list/go.mod
+++ b/mtc-log-list/go.mod
@@ -1,0 +1,14 @@
+module filippo.io/mostly-harmless/mtc-log-list
+
+go 1.26.0
+
+require (
+	filippo.io/mldsa v0.0.0-20260711112038-ff3f469cee29
+	filippo.io/torchwood v0.9.1-0.20260706112420-c22a68158d96
+)
+
+require (
+	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+)

--- a/mtc-log-list/go.sum
+++ b/mtc-log-list/go.sum
@@ -1,0 +1,10 @@
+filippo.io/mldsa v0.0.0-20260711112038-ff3f469cee29 h1:11cJmDX5FvZu/znhVjfwxs9jZcos6d8O6Bc9Fpdv87Y=
+filippo.io/mldsa v0.0.0-20260711112038-ff3f469cee29/go.mod h1:32qQ5yj3R24Eu03iWFWchdC3OB653wPvoepWejkefbY=
+filippo.io/torchwood v0.9.1-0.20260706112420-c22a68158d96 h1:TudMUuGAGLkZJBDwmtYqaNU01zGxsa6eE8ZqiQPNmPY=
+filippo.io/torchwood v0.9.1-0.20260706112420-c22a68158d96/go.mod h1:0PCbID7CT1MlVWx2upf6qN9QFHV1k9lR7PFXAYeExMk=
+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=

--- a/mtc-log-list/index.html
+++ b/mtc-log-list/index.html
@@ -4,13 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MTC log-list entry generator</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bitter&family=Raleway&family=Source+Code+Pro&display=swap" rel="stylesheet">
 <style>
 :root { color-scheme: light dark; --yellow:#ffd447; --ink:#181818; --paper:#fff; --muted:#666; }
 @media (prefers-color-scheme:dark) { :root { --paper:#171717; --ink:#eee; --muted:#aaa; } }
 * { box-sizing:border-box; }
-body { margin:0; background:var(--paper); color:var(--ink); font:16px/1.5 system-ui,sans-serif; }
+body { margin:0; background:var(--paper); color:var(--ink); font:16px/1.4 "Raleway",sans-serif; }
 main { max-width:700px; margin:72px auto; padding:0 20px; }
-h1,h2 { font-family:Georgia,serif; line-height:1.15; }
+h1,h2 { font-family:"Bitter",serif; line-height:1.15; }
 h1 { font-size:2.25rem; margin-bottom:.4rem; }
 a { color:inherit; text-decoration-thickness:1px; }
 .intro { color:var(--muted); margin-bottom:2.5rem; }
@@ -18,7 +21,7 @@ label { display:block; font-weight:650; margin:1.25rem 0 .35rem; }
 .hint { color:var(--muted); font-size:.9rem; margin:.3rem 0 0; }
 input, textarea, button { font:inherit; }
 input[type=text], input[type=url], input[type=number], textarea { width:100%; padding:.7rem .8rem; border:1px solid #999; border-radius:3px; background:var(--paper); color:var(--ink); }
-textarea { min-height:9rem; resize:vertical; font-family:ui-monospace,monospace; font-size:.88rem; }
+textarea { min-height:9rem; resize:vertical; font-family:"Source Code Pro",monospace; font-size:.88rem; -webkit-font-smoothing:antialiased; }
 button { margin-top:1.5rem; padding:.7rem 1rem; border:1px solid var(--ink); border-radius:3px; background:var(--yellow); color:#111; cursor:pointer; font-weight:700; }
 button:disabled { opacity:.55; cursor:wait; }
 #error { color:#b42318; white-space:pre-wrap; margin-top:1rem; }

--- a/mtc-log-list/index.html
+++ b/mtc-log-list/index.html
@@ -81,7 +81,8 @@ document.querySelector('#form').addEventListener('submit', async e => {
   try {
     const caid = document.querySelector('#caid').value.trim();
     const lognum = document.querySelector('#lognum').value;
-    const origin = `oid/1.3.6.1.4.1.${caid}.0.${lognum}`;
+    const cosigner = `oid/1.3.6.1.4.1.${caid}`;
+    const origin = `${cosigner}.0.${lognum}`;
     const file = document.querySelector('#key').files[0];
     const pasted = document.querySelector('#key-text').value.trim();
     if (!file && !pasted) throw new Error('Select a public key file or paste a public key.');
@@ -89,7 +90,7 @@ document.querySelector('#form').addEventListener('submit', async e => {
     const bytes = file
       ? new Uint8Array(await file.arrayBuffer())
       : new TextEncoder().encode(pasted);
-    const r = generateLogListEntry(origin, bytes);
+    const r = generateLogListEntry(cosigner, bytes);
     if (r.error) throw new Error(r.error);
     const contact = document.querySelector('#contact').value.trim();
     document.querySelector('#output').value = r.output.replace('qpd 86400', `origin ${origin}\nqpd 86400`).replace('contact https://github.com/your-org/your-repo/issues', `contact ${contact}`);

--- a/mtc-log-list/index.html
+++ b/mtc-log-list/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MTC log-list entry generator</title>
+<style>
+:root { color-scheme: light dark; --yellow:#ffd447; --ink:#181818; --paper:#fff; --muted:#666; }
+@media (prefers-color-scheme:dark) { :root { --paper:#171717; --ink:#eee; --muted:#aaa; } }
+* { box-sizing:border-box; }
+body { margin:0; background:var(--paper); color:var(--ink); font:16px/1.5 system-ui,sans-serif; }
+main { max-width:700px; margin:72px auto; padding:0 20px; }
+h1,h2 { font-family:Georgia,serif; line-height:1.15; }
+h1 { font-size:2.25rem; margin-bottom:.4rem; }
+a { color:inherit; text-decoration-thickness:1px; }
+.intro { color:var(--muted); margin-bottom:2.5rem; }
+label { display:block; font-weight:650; margin:1.25rem 0 .35rem; }
+.hint { color:var(--muted); font-size:.9rem; margin:.3rem 0 0; }
+input, textarea, button { font:inherit; }
+input[type=text], input[type=url], input[type=number], textarea { width:100%; padding:.7rem .8rem; border:1px solid #999; border-radius:3px; background:var(--paper); color:var(--ink); }
+textarea { min-height:9rem; resize:vertical; font-family:ui-monospace,monospace; font-size:.88rem; }
+button { margin-top:1.5rem; padding:.7rem 1rem; border:1px solid var(--ink); border-radius:3px; background:var(--yellow); color:#111; cursor:pointer; font-weight:700; }
+button:disabled { opacity:.55; cursor:wait; }
+#error { color:#b42318; white-space:pre-wrap; margin-top:1rem; }
+#result { margin-top:2.5rem; display:none; }
+.actions { display:flex; gap:.7rem; }
+.actions button { margin-top:.5rem; background:var(--paper); color:var(--ink); }
+hr { border:0; border-top:1px solid #bbb; margin:3rem 0 1.5rem; }
+footer { color:var(--muted); font-size:.9rem; }
+</style>
+</head>
+<body><main>
+<h1>MTC log-list entry generator</h1>
+<p class="intro">Generate an entry for a <a href="https://witness-network.org/log-list-format">witness-network log list</a>. Everything runs locally in your browser.</p>
+<form id="form">
+<label for="caid">CA ID</label>
+<input id="caid" type="text" inputmode="decimal" placeholder="32473.2" required pattern="[0-9]+(?:\.[0-9]+)*">
+<p class="hint">The trust anchor ID without the <code>1.3.6.1.4.1.</code> prefix.</p>
+
+<label for="lognum">Log number</label>
+<input id="lognum" type="number" min="1" max="65535" value="1" required>
+
+<label for="key">ML-DSA-44 public key</label>
+<input id="key" type="file" required>
+<p class="hint">A raw ML-DSA-44 public key, or a PKIX SubjectPublicKeyInfo in DER or PEM (<code>PUBLIC KEY</code>) form.</p>
+
+<label for="qpd">Maximum checkpoint requests per day</label>
+<input id="qpd" type="number" min="1" max="2147483647" value="86400" required>
+
+<label for="contact">Operator contact</label>
+<input id="contact" type="text" placeholder="https://example.com/security" required>
+
+<button id="generate" type="submit" disabled>Loading Go…</button>
+<div id="error" role="alert"></div>
+</form>
+<section id="result">
+<h2>Log-list entry</h2>
+<textarea id="output" readonly spellcheck="false"></textarea>
+<div class="actions"><button id="copy" type="button">Copy</button></div>
+<p class="hint">The origin is included explicitly and follows <a href="https://c2sp.org/mtc-tlog">c2sp.org/mtc-tlog</a>.</p>
+</section>
+<hr><footer>Built with Go WebAssembly and <a href="https://filippo.io/torchwood">Torchwood</a>.</footer>
+</main>
+<script src="wasm_exec.js"></script>
+<script>
+const button = document.querySelector('#generate');
+const error = document.querySelector('#error');
+const go = new Go();
+fetch('main.wasm').then(r => {
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.arrayBuffer();
+}).then(bytes => WebAssembly.instantiate(bytes, go.importObject)).then(({instance}) => {
+  go.run(instance); button.disabled = false; button.textContent = 'Generate entry';
+}).catch(e => { error.textContent = 'Failed to load Go WebAssembly: ' + e; });
+
+document.querySelector('#form').addEventListener('submit', async e => {
+  e.preventDefault(); error.textContent = '';
+  try {
+    const caid = document.querySelector('#caid').value.trim();
+    const lognum = document.querySelector('#lognum').value;
+    const origin = `oid/1.3.6.1.4.1.${caid}.0.${lognum}`;
+    const bytes = new Uint8Array(await document.querySelector('#key').files[0].arrayBuffer());
+    const r = generateLogListEntry(origin, bytes);
+    if (r.error) throw new Error(r.error);
+    const qpd = document.querySelector('#qpd').value;
+    const contact = document.querySelector('#contact').value.trim();
+    document.querySelector('#output').value = r.output.replace('qpd 86400', `origin ${origin}\nqpd ${qpd}`).replace('contact https://github.com/your-org/your-repo/issues', `contact ${contact}`);
+    document.querySelector('#result').style.display = 'block';
+  } catch (e) { error.textContent = e.message; document.querySelector('#result').style.display = 'none'; }
+});
+document.querySelector('#copy').addEventListener('click', async () => {
+  await navigator.clipboard.writeText(document.querySelector('#output').value);
+  document.querySelector('#copy').textContent = 'Copied'; setTimeout(() => document.querySelector('#copy').textContent = 'Copy', 1200);
+});
+</script>
+</body></html>

--- a/mtc-log-list/index.html
+++ b/mtc-log-list/index.html
@@ -40,9 +40,12 @@ footer { color:var(--muted); font-size:.9rem; }
 <label for="lognum">Log number</label>
 <input id="lognum" type="number" min="1" max="65535" value="1" required>
 
-<label for="key">ML-DSA-44 public key</label>
-<input id="key" type="file" required>
+<label for="key">ML-DSA-44 public key file</label>
+<input id="key" type="file">
 <p class="hint">A raw ML-DSA-44 public key, or a PKIX SubjectPublicKeyInfo in DER or PEM (<code>PUBLIC KEY</code>) form.</p>
+
+<label for="key-text">Or paste the public key</label>
+<textarea id="key-text" placeholder="Base64-encoded raw key or DER SubjectPublicKeyInfo, or a PEM PUBLIC KEY block" spellcheck="false"></textarea>
 
 <label for="contact">Operator contact</label>
 <input id="contact" type="text" placeholder="https://example.com/security" required>
@@ -56,7 +59,7 @@ footer { color:var(--muted); font-size:.9rem; }
 <div class="actions"><button id="copy" type="button">Copy</button></div>
 <p class="hint">The origin is included explicitly and follows <a href="https://c2sp.org/mtc-tlog">c2sp.org/mtc-tlog</a>.</p>
 </section>
-<hr><footer>Built with Go WebAssembly and <a href="https://filippo.io/torchwood">Torchwood</a>.</footer>
+<hr><footer>Built with Go WebAssembly and <a href="https://filippo.io/torchwood">Torchwood</a> by <a href="https://geomys.org">Geomys</a>.</footer>
 </main>
 <script src="wasm_exec.js"></script>
 <script>
@@ -76,7 +79,13 @@ document.querySelector('#form').addEventListener('submit', async e => {
     const caid = document.querySelector('#caid').value.trim();
     const lognum = document.querySelector('#lognum').value;
     const origin = `oid/1.3.6.1.4.1.${caid}.0.${lognum}`;
-    const bytes = new Uint8Array(await document.querySelector('#key').files[0].arrayBuffer());
+    const file = document.querySelector('#key').files[0];
+    const pasted = document.querySelector('#key-text').value.trim();
+    if (!file && !pasted) throw new Error('Select a public key file or paste a public key.');
+    if (file && pasted) throw new Error('Provide the public key either as a file or as pasted text, not both.');
+    const bytes = file
+      ? new Uint8Array(await file.arrayBuffer())
+      : new TextEncoder().encode(pasted);
     const r = generateLogListEntry(origin, bytes);
     if (r.error) throw new Error(r.error);
     const contact = document.querySelector('#contact').value.trim();

--- a/mtc-log-list/index.html
+++ b/mtc-log-list/index.html
@@ -44,9 +44,6 @@ footer { color:var(--muted); font-size:.9rem; }
 <input id="key" type="file" required>
 <p class="hint">A raw ML-DSA-44 public key, or a PKIX SubjectPublicKeyInfo in DER or PEM (<code>PUBLIC KEY</code>) form.</p>
 
-<label for="qpd">Maximum checkpoint requests per day</label>
-<input id="qpd" type="number" min="1" max="2147483647" value="86400" required>
-
 <label for="contact">Operator contact</label>
 <input id="contact" type="text" placeholder="https://example.com/security" required>
 
@@ -82,9 +79,8 @@ document.querySelector('#form').addEventListener('submit', async e => {
     const bytes = new Uint8Array(await document.querySelector('#key').files[0].arrayBuffer());
     const r = generateLogListEntry(origin, bytes);
     if (r.error) throw new Error(r.error);
-    const qpd = document.querySelector('#qpd').value;
     const contact = document.querySelector('#contact').value.trim();
-    document.querySelector('#output').value = r.output.replace('qpd 86400', `origin ${origin}\nqpd ${qpd}`).replace('contact https://github.com/your-org/your-repo/issues', `contact ${contact}`);
+    document.querySelector('#output').value = r.output.replace('qpd 86400', `origin ${origin}\nqpd 86400`).replace('contact https://github.com/your-org/your-repo/issues', `contact ${contact}`);
     document.querySelector('#result').style.display = 'block';
   } catch (e) { error.textContent = e.message; document.querySelector('#result').style.display = 'none'; }
 });

--- a/mtc-log-list/main.go
+++ b/mtc-log-list/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"syscall/js"
 
 	"filippo.io/mldsa"
+	mldsa_x509 "filippo.io/mldsa/x509"
 	"filippo.io/torchwood"
 )
 
@@ -50,7 +50,7 @@ func makeVKey(name string, input []byte) (string, error) {
 		der = block.Bytes
 	}
 	var pk *mldsa.PublicKey
-	if key, err := x509.ParsePKIXPublicKey(der); err == nil {
+	if key, err := mldsa_x509.ParsePKIXPublicKey(der); err == nil {
 		var ok bool
 		pk, ok = key.(*mldsa.PublicKey)
 		if !ok || pk.Parameters() != mldsa.MLDSA44() {

--- a/mtc-log-list/main.go
+++ b/mtc-log-list/main.go
@@ -37,9 +37,8 @@ func result(output, err string) any {
 
 func makeVKey(name string, input []byte) (string, error) {
 	if name == "" {
-		return "", errors.New("log origin is required")
+		return "", errors.New("cosigner name is required")
 	}
-	origin := name
 	der := input
 	if block, rest := pem.Decode(input); block != nil {
 		if len(strings.TrimSpace(string(rest))) != 0 {
@@ -67,7 +66,7 @@ func makeVKey(name string, input []byte) (string, error) {
 			return "", fmt.Errorf("parse ML-DSA-44 public key as SubjectPublicKeyInfo or raw key: %w", err)
 		}
 	}
-	v, err := torchwood.NewCosignatureVerifierFromKey(origin, pk)
+	v, err := torchwood.NewCosignatureVerifierFromKey(name, pk)
 	if err != nil {
 		return "", fmt.Errorf("make verifier key: %w", err)
 	}

--- a/mtc-log-list/main.go
+++ b/mtc-log-list/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -48,6 +49,10 @@ func makeVKey(name string, input []byte) (string, error) {
 			return "", fmt.Errorf("expected a PUBLIC KEY PEM block, got %q", block.Type)
 		}
 		der = block.Bytes
+	} else if text := strings.Join(strings.Fields(string(input)), ""); text != "" {
+		if decoded, err := base64.StdEncoding.DecodeString(text); err == nil {
+			der = decoded
+		}
 	}
 	var pk *mldsa.PublicKey
 	if key, err := mldsa_x509.ParsePKIXPublicKey(der); err == nil {

--- a/mtc-log-list/main.go
+++ b/mtc-log-list/main.go
@@ -1,0 +1,75 @@
+// Command mtc-log-list is a WebAssembly helper for generating witness-network
+// log-list entries for MTC tiled logs.
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+	"syscall/js"
+
+	"filippo.io/mldsa"
+	"filippo.io/torchwood"
+)
+
+func generate(_ js.Value, args []js.Value) any {
+	if len(args) != 2 {
+		return result("", "internal error: wrong argument count")
+	}
+	name := strings.TrimSpace(args[0].String())
+	key := make([]byte, args[1].Get("byteLength").Int())
+	if n := js.CopyBytesToGo(key, args[1]); n != len(key) {
+		return result("", "internal error: failed to read key file")
+	}
+	vkey, err := makeVKey(name, key)
+	if err != nil {
+		return result("", err.Error())
+	}
+	return result("vkey "+vkey+"\nqpd 86400\ncontact https://github.com/your-org/your-repo/issues\n", "")
+}
+
+func result(output, err string) any {
+	return map[string]any{"output": output, "error": err}
+}
+
+func makeVKey(name string, input []byte) (string, error) {
+	if name == "" {
+		return "", errors.New("log origin is required")
+	}
+	origin := name
+	der := input
+	if block, rest := pem.Decode(input); block != nil {
+		if len(strings.TrimSpace(string(rest))) != 0 {
+			return "", errors.New("PEM contains trailing data")
+		}
+		if block.Type != "PUBLIC KEY" {
+			return "", fmt.Errorf("expected a PUBLIC KEY PEM block, got %q", block.Type)
+		}
+		der = block.Bytes
+	}
+	var pk *mldsa.PublicKey
+	if key, err := x509.ParsePKIXPublicKey(der); err == nil {
+		var ok bool
+		pk, ok = key.(*mldsa.PublicKey)
+		if !ok || pk.Parameters() != mldsa.MLDSA44() {
+			return "", fmt.Errorf("expected an ML-DSA-44 public key, got %T", key)
+		}
+	} else {
+		pk, err = mldsa.NewPublicKey(mldsa.MLDSA44(), der)
+		if err != nil {
+			return "", fmt.Errorf("parse ML-DSA-44 public key as SubjectPublicKeyInfo or raw key: %w", err)
+		}
+	}
+	v, err := torchwood.NewCosignatureVerifierFromKey(origin, pk)
+	if err != nil {
+		return "", fmt.Errorf("make verifier key: %w", err)
+	}
+	return v.String(), nil
+}
+
+func main() {
+	js.Global().Set("generateLogListEntry", js.FuncOf(generate))
+	select {}
+}

--- a/mtc-log-list/wasm_exec.js
+++ b/mtc-log-list/wasm_exec.js
@@ -1,0 +1,575 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+"use strict";
+
+(() => {
+	const enosys = () => {
+		const err = new Error("not implemented");
+		err.code = "ENOSYS";
+		return err;
+	};
+
+	if (!globalThis.fs) {
+		let outputBuf = "";
+		globalThis.fs = {
+			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1, O_DIRECTORY: -1 }, // unused
+			writeSync(fd, buf) {
+				outputBuf += decoder.decode(buf);
+				const nl = outputBuf.lastIndexOf("\n");
+				if (nl != -1) {
+					console.log(outputBuf.substring(0, nl));
+					outputBuf = outputBuf.substring(nl + 1);
+				}
+				return buf.length;
+			},
+			write(fd, buf, offset, length, position, callback) {
+				if (offset !== 0 || length !== buf.length || position !== null) {
+					callback(enosys());
+					return;
+				}
+				const n = this.writeSync(fd, buf);
+				callback(null, n);
+			},
+			chmod(path, mode, callback) { callback(enosys()); },
+			chown(path, uid, gid, callback) { callback(enosys()); },
+			close(fd, callback) { callback(enosys()); },
+			fchmod(fd, mode, callback) { callback(enosys()); },
+			fchown(fd, uid, gid, callback) { callback(enosys()); },
+			fstat(fd, callback) { callback(enosys()); },
+			fsync(fd, callback) { callback(null); },
+			ftruncate(fd, length, callback) { callback(enosys()); },
+			lchown(path, uid, gid, callback) { callback(enosys()); },
+			link(path, link, callback) { callback(enosys()); },
+			lstat(path, callback) { callback(enosys()); },
+			mkdir(path, perm, callback) { callback(enosys()); },
+			open(path, flags, mode, callback) { callback(enosys()); },
+			read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
+			readdir(path, callback) { callback(enosys()); },
+			readlink(path, callback) { callback(enosys()); },
+			rename(from, to, callback) { callback(enosys()); },
+			rmdir(path, callback) { callback(enosys()); },
+			stat(path, callback) { callback(enosys()); },
+			symlink(path, link, callback) { callback(enosys()); },
+			truncate(path, length, callback) { callback(enosys()); },
+			unlink(path, callback) { callback(enosys()); },
+			utimes(path, atime, mtime, callback) { callback(enosys()); },
+		};
+	}
+
+	if (!globalThis.process) {
+		globalThis.process = {
+			getuid() { return -1; },
+			getgid() { return -1; },
+			geteuid() { return -1; },
+			getegid() { return -1; },
+			getgroups() { throw enosys(); },
+			pid: -1,
+			ppid: -1,
+			umask() { throw enosys(); },
+			cwd() { throw enosys(); },
+			chdir() { throw enosys(); },
+		}
+	}
+
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
+			}
+		}
+	}
+
+	if (!globalThis.crypto) {
+		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");
+	}
+
+	if (!globalThis.performance) {
+		throw new Error("globalThis.performance is not available, polyfill required (performance.now only)");
+	}
+
+	if (!globalThis.TextEncoder) {
+		throw new Error("globalThis.TextEncoder is not available, polyfill required");
+	}
+
+	if (!globalThis.TextDecoder) {
+		throw new Error("globalThis.TextDecoder is not available, polyfill required");
+	}
+
+	const encoder = new TextEncoder("utf-8");
+	const decoder = new TextDecoder("utf-8");
+
+	globalThis.Go = class {
+		constructor() {
+			this.argv = ["js"];
+			this.env = {};
+			this.exit = (code) => {
+				if (code !== 0) {
+					console.warn("exit code:", code);
+				}
+			};
+			this._exitPromise = new Promise((resolve) => {
+				this._resolveExitPromise = resolve;
+			});
+			this._pendingEvent = null;
+			this._scheduledTimeouts = new Map();
+			this._nextCallbackTimeoutID = 1;
+
+			const setInt64 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
+			}
+
+			const setInt32 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+			}
+
+			const getInt64 = (addr) => {
+				const low = this.mem.getUint32(addr + 0, true);
+				const high = this.mem.getInt32(addr + 4, true);
+				return low + high * 4294967296;
+			}
+
+			const loadValue = (addr) => {
+				const f = this.mem.getFloat64(addr, true);
+				if (f === 0) {
+					return undefined;
+				}
+				if (!isNaN(f)) {
+					return f;
+				}
+
+				const id = this.mem.getUint32(addr, true);
+				return this._values[id];
+			}
+
+			const storeValue = (addr, v) => {
+				const nanHead = 0x7FF80000;
+
+				if (typeof v === "number" && v !== 0) {
+					if (isNaN(v)) {
+						this.mem.setUint32(addr + 4, nanHead, true);
+						this.mem.setUint32(addr, 0, true);
+						return;
+					}
+					this.mem.setFloat64(addr, v, true);
+					return;
+				}
+
+				if (v === undefined) {
+					this.mem.setFloat64(addr, 0, true);
+					return;
+				}
+
+				let id = this._ids.get(v);
+				if (id === undefined) {
+					id = this._idPool.pop();
+					if (id === undefined) {
+						id = this._values.length;
+					}
+					this._values[id] = v;
+					this._goRefCounts[id] = 0;
+					this._ids.set(v, id);
+				}
+				this._goRefCounts[id]++;
+				let typeFlag = 0;
+				switch (typeof v) {
+					case "object":
+						if (v !== null) {
+							typeFlag = 1;
+						}
+						break;
+					case "string":
+						typeFlag = 2;
+						break;
+					case "symbol":
+						typeFlag = 3;
+						break;
+					case "function":
+						typeFlag = 4;
+						break;
+				}
+				this.mem.setUint32(addr + 4, nanHead | typeFlag, true);
+				this.mem.setUint32(addr, id, true);
+			}
+
+			const loadSlice = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+			}
+
+			const loadSliceOfValues = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				const a = new Array(len);
+				for (let i = 0; i < len; i++) {
+					a[i] = loadValue(array + i * 8);
+				}
+				return a;
+			}
+
+			const loadString = (addr) => {
+				const saddr = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
+			}
+
+			const testCallExport = (a, b) => {
+				this._inst.exports.testExport0();
+				return this._inst.exports.testExport(a, b);
+			}
+
+			const timeOrigin = Date.now() - performance.now();
+			this.importObject = {
+				_gotest: {
+					add: (a, b) => a + b,
+					callExport: testCallExport,
+				},
+				gojs: {
+					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
+					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
+					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
+					// This changes the SP, thus we have to update the SP used by the imported function.
+
+					// func wasmExit(code int32)
+					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
+						const code = this.mem.getInt32(sp + 8, true);
+						this.exited = true;
+						delete this._inst;
+						delete this._values;
+						delete this._goRefCounts;
+						delete this._ids;
+						delete this._idPool;
+						this.exit(code);
+					},
+
+					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
+					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
+						const fd = getInt64(sp + 8);
+						const p = getInt64(sp + 16);
+						const n = this.mem.getInt32(sp + 24, true);
+						fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+					},
+
+					// func resetMemoryDataView()
+					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
+						this.mem = new DataView(this._inst.exports.mem.buffer);
+					},
+
+					// func nanotime1() int64
+					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
+					},
+
+					// func walltime() (sec int64, nsec int32)
+					"runtime.walltime": (sp) => {
+						sp >>>= 0;
+						const msec = (new Date).getTime();
+						setInt64(sp + 8, msec / 1000);
+						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
+					},
+
+					// func scheduleTimeoutEvent(delay int64) int32
+					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this._nextCallbackTimeoutID;
+						this._nextCallbackTimeoutID++;
+						this._scheduledTimeouts.set(id, setTimeout(
+							() => {
+								this._resume();
+								while (this._scheduledTimeouts.has(id)) {
+									// for some reason Go failed to register the timeout event, log and try again
+									// (temporary workaround for https://github.com/golang/go/issues/28975)
+									console.warn("scheduleTimeoutEvent: missed timeout event");
+									this._resume();
+								}
+							},
+							getInt64(sp + 8),
+						));
+						this.mem.setInt32(sp + 16, id, true);
+					},
+
+					// func clearTimeoutEvent(id int32)
+					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getInt32(sp + 8, true);
+						clearTimeout(this._scheduledTimeouts.get(id));
+						this._scheduledTimeouts.delete(id);
+					},
+
+					// func getRandomData(r []byte)
+					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
+						crypto.getRandomValues(loadSlice(sp + 8));
+					},
+
+					// func finalizeRef(v ref)
+					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getUint32(sp + 8, true);
+						this._goRefCounts[id]--;
+						if (this._goRefCounts[id] === 0) {
+							const v = this._values[id];
+							this._values[id] = null;
+							this._ids.delete(v);
+							this._idPool.push(id);
+						}
+					},
+
+					// func stringVal(value string) ref
+					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, loadString(sp + 8));
+					},
+
+					// func valueGet(v ref, p string) ref
+					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
+						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
+						storeValue(sp + 32, result);
+					},
+
+					// func valueSet(v ref, p string, x ref)
+					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
+					},
+
+					// func valueDelete(v ref, p string)
+					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
+						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
+					},
+
+					// func valueIndex(v ref, i int) ref
+					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
+					},
+
+					// valueSetIndex(v ref, i int, x ref)
+					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
+					},
+
+					// func valueCall(v ref, m string, args []ref) (ref, bool)
+					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const m = Reflect.get(v, loadString(sp + 16));
+							const args = loadSliceOfValues(sp + 32);
+							const result = Reflect.apply(m, v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, result);
+							this.mem.setUint8(sp + 64, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, err);
+							this.mem.setUint8(sp + 64, 0);
+						}
+					},
+
+					// func valueInvoke(v ref, args []ref) (ref, bool)
+					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.apply(v, undefined, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueNew(v ref, args []ref) (ref, bool)
+					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.construct(v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueLength(v ref) int
+					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
+					},
+
+					// valuePrepareString(v ref) (ref, int)
+					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
+						const str = encoder.encode(String(loadValue(sp + 8)));
+						storeValue(sp + 16, str);
+						setInt64(sp + 24, str.length);
+					},
+
+					// valueLoadString(v ref, b []byte)
+					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
+						const str = loadValue(sp + 8);
+						loadSlice(sp + 16).set(str);
+					},
+
+					// func valueInstanceOf(v ref, t ref) bool
+					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
+						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
+					},
+
+					// func copyBytesToGo(dst []byte, src ref) (int, bool)
+					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
+						const dst = loadSlice(sp + 8);
+						const src = loadValue(sp + 32);
+						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					// func copyBytesToJS(dst ref, src []byte) (int, bool)
+					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
+						const dst = loadValue(sp + 8);
+						const src = loadSlice(sp + 16);
+						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					"debug": (value) => {
+						console.log(value);
+					},
+				}
+			};
+		}
+
+		async run(instance) {
+			if (!(instance instanceof WebAssembly.Instance)) {
+				throw new Error("Go.run: WebAssembly.Instance expected");
+			}
+			this._inst = instance;
+			this.mem = new DataView(this._inst.exports.mem.buffer);
+			this._values = [ // JS values that Go currently has references to, indexed by reference id
+				NaN,
+				0,
+				null,
+				true,
+				false,
+				globalThis,
+				this,
+			];
+			this._goRefCounts = new Array(this._values.length).fill(Infinity); // number of references that Go has to a JS value, indexed by reference id
+			this._ids = new Map([ // mapping from JS values to reference ids
+				[0, 1],
+				[null, 2],
+				[true, 3],
+				[false, 4],
+				[globalThis, 5],
+				[this, 6],
+			]);
+			this._idPool = [];   // unused ids that have been garbage collected
+			this.exited = false; // whether the Go program has exited
+
+			// Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
+			let offset = 4096;
+
+			const strPtr = (str) => {
+				const ptr = offset;
+				const bytes = encoder.encode(str + "\0");
+				new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes);
+				offset += bytes.length;
+				if (offset % 8 !== 0) {
+					offset += 8 - (offset % 8);
+				}
+				return ptr;
+			};
+
+			const argc = this.argv.length;
+
+			const argvPtrs = [];
+			this.argv.forEach((arg) => {
+				argvPtrs.push(strPtr(arg));
+			});
+			argvPtrs.push(0);
+
+			const keys = Object.keys(this.env).sort();
+			keys.forEach((key) => {
+				argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+			});
+			argvPtrs.push(0);
+
+			const argv = offset;
+			argvPtrs.forEach((ptr) => {
+				this.mem.setUint32(offset, ptr, true);
+				this.mem.setUint32(offset + 4, 0, true);
+				offset += 8;
+			});
+
+			// The linker guarantees global data starts from at least wasmMinDataAddr.
+			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
+			const wasmMinDataAddr = 4096 + 8192;
+			if (offset >= wasmMinDataAddr) {
+				throw new Error("total length of command line and environment variables exceeds limit");
+			}
+
+			this._inst.exports.run(argc, argv);
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+			await this._exitPromise;
+		}
+
+		_resume() {
+			if (this.exited) {
+				throw new Error("Go program has already exited");
+			}
+			this._inst.exports.resume();
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+		}
+
+		_makeFuncWrapper(id) {
+			const go = this;
+			return function () {
+				const event = { id: id, this: this, args: arguments };
+				go._pendingEvent = event;
+				go._resume();
+				return event.result;
+			};
+		}
+	}
+})();


### PR DESCRIPTION
Adds a single-page, client-side generator for witness-network log-list entries for MTC issuance logs.

The tool:

- derives the checkpoint origin from the CA ID and log number according to c2sp.org/mtc-tlog
- accepts raw ML-DSA-44 public keys and PKIX SubjectPublicKeyInfo files in DER or PEM form
- generates verifier keys with Torchwood in Go WebAssembly
- includes qpd and contact fields, and a copy button
- has no server-side component and works through htmlpreview.github.io

Tested in Chromium with a generated raw ML-DSA-44 public key.